### PR TITLE
Sdl2graphics

### DIFF
--- a/Guisan.vcxproj
+++ b/Guisan.vcxproj
@@ -36,12 +36,12 @@
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
@@ -112,6 +112,29 @@
       <AdditionalLibraryDirectories>C:\Users\Gwilherm\SDL\SDL2_ttf-2.0.14\lib\x86;C:\Users\Gwilherm\SDL\SDL2_image-2.0.3\lib\x86;C:\Users\Gwilherm\SDL\SDL2-2.0.8\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>C:\Users\Gwilherm\SDL\SDL2_ttf-2.0.14\include;C:\Users\Gwilherm\SDL\SDL2_image-2.0.3\include;C:\Users\Gwilherm\SDL\SDL2-2.0.8\include;.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\Users\Gwilherm\SDL\SDL2_ttf-2.0.14\lib\x64;C:\Users\Gwilherm\SDL\SDL2_image-2.0.3\lib\x64;C:\Users\Gwilherm\SDL\SDL2-2.0.8\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>C:\Users\Gwilherm\SDL\SDL2_ttf-2.0.14\include;C:\Users\Gwilherm\SDL\SDL2_image-2.0.3\include;C:\Users\Gwilherm\SDL\SDL2-2.0.8\include;.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\Users\Gwilherm\SDL\SDL2_ttf-2.0.14\lib\x64;C:\Users\Gwilherm\SDL\SDL2_image-2.0.3\lib\x64;C:\Users\Gwilherm\SDL\SDL2-2.0.8\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\actionevent.cpp" />
     <ClCompile Include="src\basiccontainer.cpp" />
@@ -139,6 +162,7 @@
     <ClCompile Include="src\opengl\openglimage.cpp" />
     <ClCompile Include="src\rectangle.cpp" />
     <ClCompile Include="src\sdl\sdl.cpp" />
+    <ClCompile Include="src\sdl\sdl2graphics.cpp" />
     <ClCompile Include="src\sdl\sdlgraphics.cpp" />
     <ClCompile Include="src\sdl\sdlimage.cpp" />
     <ClCompile Include="src\sdl\sdlimageloader.cpp" />

--- a/SConstruct
+++ b/SConstruct
@@ -120,6 +120,7 @@ widget_headers = [
 ]
 sdl2_headers = [
     'include/guisan/sdl/sdlgraphics.hpp',
+    'include/guisan/sdl/sdl2graphics.hpp',
     'include/guisan/sdl/sdlimage.hpp',
     'include/guisan/sdl/sdlimageloader.hpp',
     'include/guisan/sdl/sdlinput.hpp',

--- a/examples/SConscript
+++ b/examples/SConscript
@@ -21,6 +21,16 @@ if env['HAVE_SDL2']:
 		target = 'sdlwidgets',
 		source = ['sdlwidgets.cpp']
 	)
+	
+	sdl2widgets = env.Clone()
+	sdl2widgets.ParseConfig('pkg-config --cflags --libs sdl2')
+	sdl2widgets.ParseConfig('pkg-config --cflags --libs SDL2_image')
+	sdl2widgets.ParseConfig('pkg-config --cflags --libs SDL2_ttf')
+	sdl2widgets.Prepend(LIBS = 'guisan')
+	sdl2widgets.Program(
+		target = 'sdl2widgets',
+		source = ['sdl2widgets.cpp']
+	)
 
 	sdlaction = env.Clone()
 	sdlaction.ParseConfig('pkg-config --cflags --libs sdl2')

--- a/examples/sdl2widgets.cpp
+++ b/examples/sdl2widgets.cpp
@@ -1,0 +1,375 @@
+/**
+ * SDL widgets example for Guichan.
+ */
+
+// Include all necessary headers.
+#include <iostream>
+#include <guisan.hpp>
+#include <guisan/sdl.hpp>
+#include "SDL.h"
+
+/*
+ * Common stuff we need
+ */
+bool running = true;
+
+/*
+ * SDL Stuff we need
+ */
+SDL_Window* sdlWindow;
+SDL_Renderer* sdlRenderer;
+SDL_Event event;
+
+/*
+ * Guichan SDL stuff we need
+ */
+gcn::SDLInput* input;             // Input driver
+gcn::SDL2Graphics* graphics;       // Graphics driver
+gcn::SDLImageLoader* imageLoader; // For loading images
+
+/*
+ * Guichan stuff we need
+ */
+gcn::Gui* gui;            // A Gui object - binds it all together
+gcn::ImageFont* font;     // A font
+
+/*
+ * All of the default widgets
+ */
+gcn::Container* top;                 // A top container
+gcn::Label* label;                   // A label
+gcn::Icon* icon;                     // An icon (image)
+gcn::Button* button;                 // A button
+gcn::TextField* textField;           // One-line text field
+gcn::TextBox* textBox;               // Multi-line text box
+gcn::ScrollArea* textBoxScrollArea;  // Scroll area for the text box
+gcn::ListBox* listBox;               // A list box
+gcn::DropDown* dropDown;             // Drop down
+gcn::CheckBox* checkBox1;            // Two checkboxes
+gcn::CheckBox* checkBox2;
+gcn::RadioButton* radioButton1;      // Three radio buttons
+gcn::RadioButton* radioButton2;
+gcn::RadioButton* radioButton3;
+gcn::Slider* slider;                 // A slider
+gcn::Image *image;                   // An image for the icon
+gcn::Window *window;
+gcn::Image *guisanLogoImage;
+gcn::Icon* guisanLogoIcon;
+gcn::ScrollArea* nestedScrollArea;
+gcn::Container* nestedContainer;
+gcn::Slider* nestedSlider;
+
+/*
+ * List boxes and dropdowns needs an instance of a listmodel
+ * to know what elements they have.
+ */
+class DemoListModel : public gcn::ListModel
+{
+public:
+	int getNumberOfElements()
+	{
+		return 5;
+	}
+
+	std::string getElementAt(int i)
+	{
+		switch(i) {
+			case 0:
+				return std::string("zero");
+			case 1:
+				return std::string("one");
+			case 2:
+				return std::string("two");
+			case 3:
+				return std::string("three");
+			case 4:
+				return std::string("four");
+			default: // Just to keep warnings away
+				return std::string("");
+		}
+	}
+};
+
+DemoListModel demoListModel;
+
+void
+initWidgets()
+{
+
+	/*
+	 * Create all the widgets
+	 */
+	label = new gcn::Label("Label");
+
+	image = gcn::Image::load("guisan.png");
+	icon = new gcn::Icon(image);
+
+	button = new gcn::Button("Button");
+
+	textField = new gcn::TextField("Text field");
+
+	textBox = new gcn::TextBox("Lorem ipsum dolor sit amet consectetur\n"
+                "adipiscing elit Integer vitae ultrices\n"
+		"eros Curabitur malesuada dolor imperdieat\n"
+		"ante facilisis ut convallis sem rutrum\n"
+		"Praesent consequat urna convallis leo\n"
+		"aliquam pellentesque Integer laoreet enim\n"
+		"vehicula libero blandit at pellentesque\n"
+		"ipsum vehicula Mauris id turpis hendrerit\n"
+		"tempor velit nec hendrerit nulla");
+	textBoxScrollArea = new gcn::ScrollArea(textBox);
+	textBoxScrollArea->setWidth(270);
+	textBoxScrollArea->setHeight(100);
+	textBoxScrollArea->setBorderSize(1);
+
+	listBox = new gcn::ListBox(&demoListModel);
+	listBox->setBorderSize(1);
+
+	dropDown = new gcn::DropDown(&demoListModel);
+    
+	checkBox1 = new gcn::CheckBox("Checkbox 1");
+	checkBox2 = new gcn::CheckBox("Checkbox 2");
+
+	radioButton1 = new gcn::RadioButton("Radio Button 1", "radiogroup", true);
+	radioButton2 = new gcn::RadioButton("Radio Button 2", "radiogroup");
+	radioButton3 = new gcn::RadioButton("Radio Button 3", "radiogroup");
+
+	slider = new gcn::Slider(0, 10);
+	slider->setSize(100, 10);
+
+	window = new gcn::Window("I am a window  Drag me");
+	window->setBaseColor(gcn::Color(212, 255, 150, 190));
+	
+	guisanLogoImage = gcn::Image::load("guisan-logo.png");
+	guisanLogoIcon = new gcn::Icon(guisanLogoImage);
+	window->add(guisanLogoIcon);
+	window->resizeToContent();
+	
+	nestedSlider = new gcn::Slider(0, 10);
+	nestedSlider->setSize(100, 10);
+	
+	nestedContainer = new gcn::Container();
+	nestedContainer->setSize(400, 200);
+	nestedContainer->add(nestedSlider, 50, 70);
+	
+	nestedScrollArea = new gcn::ScrollArea(nestedContainer);
+	nestedScrollArea->setSize(180, 90);
+	nestedScrollArea->setBorderSize(1);
+
+	/*
+	 * Add them to the top container
+	 */
+	top->add(label, 290, 10);
+	top->add(icon, 10, 10);
+	top->add(button, 325, 10);
+	top->add(textField, 375, 10);
+	top->add(textBoxScrollArea, 290, 50);
+	top->add(listBox, 290, 200);
+	top->add(dropDown, 580, 10);
+	top->add(checkBox1, 580, 50);
+	top->add(checkBox2, 580, 70);
+	top->add(radioButton1, 580, 120);
+	top->add(radioButton2, 580, 140);
+	top->add(radioButton3, 580, 160);
+	top->add(slider, 580, 200);
+	top->add(window, 100, 350);
+	top->add(nestedScrollArea, 440, 350);
+}
+
+/**
+ * Initializes the application
+ */
+void
+init()
+{
+	/*
+	 * Here we initialize SDL as we would do with any SDL application.
+	 */
+	SDL_Init(SDL_INIT_VIDEO);
+	/*sdlWindow = SDL_CreateWindow("guisan SDL2 widget example",
+		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 700, 480, 0);*/
+		
+	SDL_CreateWindowAndRenderer(700, 480, 0, &sdlWindow, &sdlRenderer); 
+	SDL_SetWindowTitle(sdlWindow, "guisan SDL2 widget example");
+	SDL_SetWindowPosition(sdlWindow, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED);
+
+	// We want to enable key repeat
+	//SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
+
+	/*
+	 * Now it's time for Guisan SDL stuff
+	 */
+	imageLoader = new gcn::SDLImageLoader();
+	imageLoader->setRenderer(sdlRenderer);
+	// The ImageLoader in use is static and must be set to be
+	// able to load images
+	// A Renderer needs to be specified too to be able to do the 
+	// conversion to textures directly on loading; otherwise, SDL2Graphics
+	// will have to do it internally each time you draw it...
+	gcn::Image::setImageLoader(imageLoader);
+	graphics = new gcn::SDL2Graphics();
+	// Set the target for the graphics object to be the renderer.
+	// We also need to pass screen dimensions because we cannot 
+	// get them back from the renderer object. 
+	graphics->setTarget(sdlRenderer, 700, 480);
+	input = new gcn::SDLInput();
+
+	/*
+	 * Last but not least it's time to initialize and create the gui
+	 * with Guichan stuff.
+	 */
+	top = new gcn::Container();
+	// Set the dimension of the top container to match the screen.
+	top->setDimension(gcn::Rectangle(0, 0, 700, 480));
+	gui = new gcn::Gui();
+	// Set gui to use the SDLGraphics object.
+	gui->setGraphics(graphics);
+	// Set gui to use the SDLInput object
+	gui->setInput(input);
+	// Set the top container
+	gui->setTop(top);
+	// Load the image font.
+	font = new gcn::ImageFont("fixedfont.bmp",
+		" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+	// The global font is static and must be set.
+	gcn::Widget::setGlobalFont(font);
+
+	initWidgets();
+}
+
+/**
+ * Halts the application
+ */
+void
+halt()
+{
+	/*
+	 * Destroy Guichan stuff
+	 */
+	delete font;
+	delete gui;
+
+	/*
+	 * Widgets
+	 */
+	delete top;
+	delete label;
+	delete icon;
+	delete button;
+	delete textField;
+	delete textBox;
+	delete textBoxScrollArea;
+	delete listBox;
+	delete dropDown;
+	delete checkBox1;
+	delete checkBox2;
+	delete radioButton1;
+	delete radioButton2;
+	delete radioButton3;
+	delete slider;
+	delete window;
+	delete guisanLogoIcon;
+	delete guisanLogoImage;
+	delete nestedScrollArea;
+	delete nestedContainer;
+	delete nestedSlider;
+    
+	/*
+	 * Destroy Guichan SDL stuff
+	 */
+	delete input;
+	delete graphics;
+	delete imageLoader;
+
+	/*
+	 * Destroy SDL stuff
+	 */
+	SDL_DestroyRenderer(sdlRenderer);
+	SDL_DestroyWindow(sdlWindow);
+	SDL_Quit();
+}
+
+/**
+ * Checks input. On escape halt the application.
+ */
+void
+checkInput()
+{
+	/*
+	 * Poll SDL events
+	 */
+	while(SDL_PollEvent(&event)) {
+		if (event.type == SDL_KEYDOWN) {
+			if (event.key.keysym.sym == SDLK_ESCAPE)
+				running = false;
+
+			if (event.key.keysym.sym == SDLK_f) {
+				if (event.key.keysym.mod & KMOD_CTRL) {
+					// TODO: Toggle full screen
+				}
+			}
+		} else if(event.type == SDL_QUIT) {
+			running = false;
+		}
+
+		/*
+		 * Now that we are done polling and using SDL events we pass
+		 * the leftovers to the SDLInput object to later be handled by
+		 * the Gui.
+		 */
+		input->pushInput(event);
+	}
+}
+
+/**
+ * Runs the application
+ */
+void
+run()
+{
+	while(running) {
+		// Poll input
+		checkInput();
+		// Let the gui perform it's logic (like handle input)
+		gui->logic();
+		SDL_RenderClear(sdlRenderer);
+		// Draw the gui
+		gui->draw();
+		// Update the screen
+		SDL_RenderPresent(sdlRenderer);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+
+	try {
+ 		init();
+		run();
+		halt();
+	}
+	/*
+	 * Catch all Guichan exceptions
+	 */
+	catch (gcn::Exception e) {
+		std::cerr << e.getMessage() << std::endl;
+		return 1;
+	}
+	/*
+	 * Catch all Std exceptions
+	 */
+	catch (std::exception e) {
+		std::cerr << "Std exception: " << e.what() << std::endl;
+		return 1;
+	}
+	/*
+	 * Catch all Unknown exceptions
+	 */
+	catch (...) {
+		std::cerr << "Unknown exception" << std::endl;
+		return 1;
+	}
+
+	return 0;
+}

--- a/include/guisan/sdl.hpp
+++ b/include/guisan/sdl.hpp
@@ -58,6 +58,7 @@
 #define GCN_SDL_HPP
 
 #include <guisan/sdl/sdlgraphics.hpp>
+#include <guisan/sdl/sdl2graphics.hpp>
 #include <guisan/sdl/sdlimage.hpp>
 #include <guisan/sdl/sdlimageloader.hpp>
 #include <guisan/sdl/sdlinput.hpp>

--- a/include/guisan/sdl/sdlgraphics.hpp
+++ b/include/guisan/sdl/sdlgraphics.hpp
@@ -82,10 +82,15 @@ namespace gcn
          * Constructor.
          */
         SDLGraphics();
-
+		
+		/**
+		 * Destructor.
+		 */
+		~SDLGraphics();
+		
         /**
          * Sets the target SDL_Surface to draw to. The target can be any
-         * SDL_Surface. This funtion also pushes a clip areas corresponding to
+         * SDL_Surface. This function also pushes a clip areas corresponding to
          * the dimension of the target.
          *
          * @param target the target to draw to.
@@ -100,7 +105,7 @@ namespace gcn
         virtual SDL_Surface* getTarget() const;
 
         /**
-         * Draws an SDL_Surface on the target surface. Normaly you'll
+         * Draws an SDL_Surface on the target surface. Normally you'll
          * use drawImage, but if you want to write SDL specific code
          * this function might come in handy.
          *

--- a/include/guisan/sdl/sdlimage.hpp
+++ b/include/guisan/sdl/sdlimage.hpp
@@ -81,8 +81,9 @@ namespace gcn
          *
          * @param surface the surface from which to load.
          * @param autoFree true if the surface should automatically be deleted.
+         * @param renderer renderer object to create the texture (last parameter to avoid breaking stuff)
          */
-        SDLImage(SDL_Surface* surface, bool autoFree);
+        SDLImage(SDL_Surface* surface, bool autoFree, SDL_Renderer* renderer = NULL);
 
         /**
          * Destructor.
@@ -95,7 +96,13 @@ namespace gcn
          * @return the SDL surface for the image.
          */
         virtual SDL_Surface* getSurface() const;
-
+		
+		/**
+		 * Gets the SDL texture for the image.
+         *
+         * @return the SDL texture for the image.
+		 */
+		virtual SDL_Texture* getTexture() const;
 
         // Inherited from Image
 
@@ -113,6 +120,8 @@ namespace gcn
 
     protected:
         SDL_Surface* mSurface;
+        SDL_Texture* mTexture = NULL;
+        SDL_Renderer* mRenderer = NULL;
         bool mAutoFree;
     };
 }

--- a/include/guisan/sdl/sdlimageloader.hpp
+++ b/include/guisan/sdl/sdlimageloader.hpp
@@ -73,13 +73,16 @@ namespace gcn
     {
     public:
 
+		void setRenderer(SDL_Renderer* renderer); 
         // Inherited from ImageLoader
 
         virtual Image* load(const std::string& filename, bool convertToDisplayFormat = true);
 
     protected:
         virtual SDL_Surface* loadSDLSurface(const std::string& filename);
+        virtual SDL_Texture* loadSDLTexture(const std::string& filename);
         virtual SDL_Surface* convertToStandardFormat(SDL_Surface* surface);
+        SDL_Renderer* mRenderer;
     };
 }
 

--- a/include/guisan/sdl/sdlpixel.hpp
+++ b/include/guisan/sdl/sdlpixel.hpp
@@ -64,7 +64,7 @@ namespace gcn
 {
 
     /**
-     * Checks a pixels color of an SDL_Surface.
+     * Checks a pixel color of an SDL_Surface.
      *
      * @param surface an SDL_Surface where to check for a pixel color.
      * @param x the x coordinate on the surface.

--- a/include/guisan/sdl/sdltruetypefont.hpp
+++ b/include/guisan/sdl/sdltruetypefont.hpp
@@ -6,11 +6,11 @@
  * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
  * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
  *
- * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ * Copyright (c) 2004 - 2008 Olof NaessÃ©n and Per Larsson
  *
  *
  * Per Larsson a.k.a finalman
- * Olof Naessén a.k.a jansem/yakslem
+ * Olof NaessÃ©n a.k.a jansem/yakslem
  *
  * Visit: http://guichan.sourceforge.net
  *
@@ -47,11 +47,7 @@
 #include <map>
 #include <string>
 
-#ifndef _WIN32
-#include <SDL2/SDL_ttf.h>
-#else
-#include <SDL_ttf.h>
-#endif
+#include "SDL_ttf.h"
 
 #include "guisan/font.hpp"
 #include "guisan/platform.hpp"
@@ -69,7 +65,7 @@ namespace gcn
 	 *       function.
 	 *
 	 * @author Walluce Pinkham
-	 * @author Olof Naessén
+	 * @author Olof NaessÃ©n
 	 */
 	class GCN_EXTENSION_DECLSPEC SDLTrueTypeFont: public Font
 	{
@@ -121,7 +117,7 @@ namespace gcn
 		/**
 		 * Sets the use of anti aliasing..
 		 *
-		 * @param antaAlias true for use of antia aliasing.
+		 * @param antaAlias true for use of antialiasing.
 		 */
 		virtual void setAntiAlias(bool antiAlias);
   

--- a/src/SConscript
+++ b/src/SConscript
@@ -58,6 +58,7 @@ if env['HAVE_SDL2']:
 	sdl_sources = [
 		'sdl/sdl.cpp',
 		'sdl/sdlgraphics.cpp',
+		'sdl/sdl2graphics.cpp',
 		'sdl/sdlimage.cpp',
 		'sdl/sdlimageloader.cpp',
 		'sdl/sdlinput.cpp',

--- a/src/sdl/sdl2graphics.cpp
+++ b/src/sdl/sdl2graphics.cpp
@@ -1,0 +1,479 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004, 2005, 2006, 2007 Olof Naessén and Per Larsson
+ * Copyright (c) 2016, 2018, 2019 Gwilherm Baudic
+ *                                                         Js_./
+ * Per Larsson a.k.a finalman                          _RqZ{a<^_aa
+ * Olof Naessén a.k.a jansem/yakslem                _asww7!uY`>  )\a//
+ *                                                 _Qhm`] _f "'c  1!5m
+ * Visit: http://guichan.darkbits.org             )Qk<P ` _: :+' .'  "{[
+ *                                               .)j(] .d_/ '-(  P .   S
+ * License: (BSD)                                <Td/Z <fP"5(\"??"\a.  .L
+ * Redistribution and use in source and          _dV>ws?a-?'      ._/L  #'
+ * binary forms, with or without                 )4d[#7r, .   '     )d`)[
+ * modification, are permitted provided         _Q-5'5W..j/?'   -?!\)cam'
+ * that the following conditions are met:       j<<WP+k/);.        _W=j f
+ * 1. Redistributions of source code must       .$%w\/]Q  . ."'  .  mj$
+ *    retain the above copyright notice,        ]E.pYY(Q]>.   a     J@\
+ *    this list of conditions and the           j(]1u<sE"L,. .   ./^ ]{a
+ *    following disclaimer.                     4'_uomm\.  )L);-4     (3=
+ * 2. Redistributions in binary form must        )_]X{Z('a_"a7'<a"a,  ]"[
+ *    reproduce the above copyright notice,       #}<]m7`Za??4,P-"'7. ).m
+ *    this list of conditions and the            ]d2e)Q(<Q(  ?94   b-  LQ/
+ *    following disclaimer in the                <B!</]C)d_, '(<' .f. =C+m
+ *    documentation and/or other materials      .Z!=J ]e []('-4f _ ) -.)m]'
+ *    provided with the distribution.          .w[5]' _[ /.)_-"+?   _/ <W"
+ * 3. Neither the name of Guichan nor the      :$we` _! + _/ .        j?
+ *    names of its contributors may be used     =3)= _f  (_yQmWW$#(    "
+ *    to endorse or promote products derived     -   W,  sQQQQmZQ#Wwa]..
+ *    from this software without specific        (js, \[QQW$QWW#?!V"".
+ *    prior written permission.                    ]y:.<\..          .
+ *                                                 -]n w/ '         [.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT       )/ )/           !
+ * HOLDERS AND CONTRIBUTORS "AS IS" AND ANY         <  (; sac    ,    '
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING,               ]^ .-  %
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF            c <   r
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR            aga<  <La
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE          5%  )P'-3L
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR        _bQf` y`..)a
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,          ,J?4P'.P"_(\?d'.,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES               _Pa,)!f/<[]/  ?"
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT      _2-..:. .r+_,.. .
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,     ?a.<%"'  " -'.a_ _,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION)                     ^
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guisan/sdl/sdl2graphics.hpp"
+
+#include "guisan/exception.hpp"
+#include "guisan/font.hpp"
+#include "guisan/image.hpp"
+#include "guisan/sdl/sdlimage.hpp"
+#include "guisan/sdl/sdlpixel.hpp"
+
+// For some reason an old version of MSVC did not like std::abs,
+// so we added this macro.
+#ifndef ABS
+#define ABS(x) ((x)<0?-(x):(x))
+#endif
+
+namespace gcn
+{
+
+    SDL2Graphics::SDL2Graphics()
+    {
+        mAlpha = false;
+    }
+    
+    SDL2Graphics::~SDL2Graphics()
+    {
+        if(mRenderTarget != NULL)
+        {
+            SDL_DestroyTexture(mTexture);
+            SDL_FreeSurface(mTarget);
+        }
+    }
+
+    void SDL2Graphics::_beginDraw()
+    {
+        Rectangle area;
+        area.x = 0;
+        area.y = 0;
+        area.width = mTarget->w;
+        area.height = mTarget->h;
+        pushClipArea(area);
+    }
+
+    void SDL2Graphics::_endDraw()
+    {
+        popClipArea();
+    }
+    
+    void SDL2Graphics::setTarget(SDL_Renderer* renderer, int width, int height)
+    {
+        mRenderTarget = renderer;
+        // An internal surface is still required to be able to handle surfaces and colorkeys
+        mTarget = SDL_CreateRGBSurface(0, width, height, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000);
+        SDL_FillRect(mTarget, NULL, SDL_MapRGB(mTarget->format, 0xff, 0, 0xff));
+        SDL_SetColorKey(mTarget, SDL_TRUE, SDL_MapRGB(mTarget->format, 0xff, 0, 0xff)); // magenta, Guisan default
+        SDL_SetSurfaceBlendMode(mTarget, SDL_BLENDMODE_NONE); // needed to cleanup temp data properly
+        mTexture = SDL_CreateTextureFromSurface(mRenderTarget, mTarget);
+        SDL_SetTextureBlendMode(mTexture, SDL_BLENDMODE_BLEND);
+    }
+
+    bool SDL2Graphics::pushClipArea(Rectangle area)
+    {
+        SDL_Rect rect;
+        bool result = Graphics::pushClipArea(area);
+
+        const ClipRectangle& carea = mClipStack.top();
+        rect.x = carea.x;
+        rect.y = carea.y;
+        rect.w = carea.width;
+        rect.h = carea.height;
+
+        SDL_RenderSetClipRect(mRenderTarget, &rect);
+
+        return result;
+    }
+
+    void SDL2Graphics::popClipArea()
+    {
+        Graphics::popClipArea();
+
+        if (mClipStack.empty())
+        {
+            return;
+        }
+
+        const ClipRectangle& carea = mClipStack.top();
+        SDL_Rect rect;
+        rect.x = carea.x;
+        rect.y = carea.y;
+        rect.w = carea.width;
+        rect.h = carea.height;
+
+        SDL_RenderSetClipRect(mRenderTarget, &rect);
+    }
+    
+    SDL_Renderer* SDL2Graphics::getTarget() const
+    {
+        return mRenderTarget;
+    }
+
+    void SDL2Graphics::drawImage(const Image* image, int srcX,
+                                int srcY, int dstX, int dstY,
+                                int width, int height)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+    
+        const ClipRectangle& top = mClipStack.top();
+        SDL_Rect src;
+        SDL_Rect dst;
+        SDL_Rect temp;
+        src.x = srcX;
+        src.y = srcY;
+        src.w = width;
+        src.h = height;
+        dst.x = dstX + top.xOffset;
+        dst.y = dstY + top.yOffset;
+        dst.w = width;
+        dst.h = height;
+        temp.x = 0;
+        temp.y = 0;
+        temp.w = width;
+        temp.h = height;
+
+        const SDLImage* srcImage = dynamic_cast<const SDLImage*>(image);
+
+        if (srcImage == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to draw an image of unknown format, must be an SDLImage.");
+        }
+        
+        if(srcImage->getTexture() == NULL)
+        {
+            SDL_FillRect(mTarget, &temp, SDL_MapRGBA(mTarget->format, 0xff, 0, 0xff, 0));
+            SDL_BlitSurface(srcImage->getSurface(), &src, mTarget, &temp);
+            SDL_UpdateTexture(mTexture, &temp, mTarget->pixels, mTarget->pitch);
+            SDL_RenderCopy(mRenderTarget, mTexture, &temp, &dst);
+        } 
+        else 
+        {
+            SDL_RenderCopy(mRenderTarget, srcImage->getTexture(), &src, &dst);
+        }
+        
+    }
+
+    void SDL2Graphics::fillRectangle(const Rectangle& rectangle)
+    {
+    if (mClipStack.empty()) {
+        throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+            "called a draw function outside of _beginDraw() and _endDraw()?");
+    }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        Rectangle area = rectangle;
+        area.x += top.xOffset;
+        area.y += top.yOffset;
+
+        if(!area.intersect(top))
+        {
+            return;
+        }
+
+        if (mAlpha)
+        {
+            int x1 = area.x > top.x ? area.x : top.x;
+            int y1 = area.y > top.y ? area.y : top.y;
+            int x2 = area.x + area.width < top.x + top.width ? area.x + area.width : top.x + top.width;
+            int y2 = area.y + area.height < top.y + top.height ? area.y + area.height : top.y + top.height;
+            int x, y;
+            SDL_Rect rect;
+            rect.x = x1;
+            rect.y = y1;
+            rect.w = x2 - x1;
+            rect.h = y2 - y1;
+            
+            saveRenderColor();
+            SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+            SDL_RenderFillRect(mRenderTarget, &rect);
+            restoreRenderColor();
+
+        }
+        else
+        {
+            SDL_Rect rect;
+            rect.x = area.x;
+            rect.y = area.y;
+            rect.w = area.width;
+            rect.h = area.height;
+
+            Uint32 color = SDL_MapRGBA(mTarget->format, mColor.r, mColor.g, mColor.b, mColor.a);
+            saveRenderColor();
+            SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+            SDL_RenderFillRect(mRenderTarget, &rect);
+            restoreRenderColor();
+            
+        }
+    }
+
+    void SDL2Graphics::drawPoint(int x, int y)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        x += top.xOffset;
+        y += top.yOffset;
+
+        if(!top.isPointInRect(x,y))
+            return;
+
+        saveRenderColor();
+        SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+        /*if (mAlpha)
+        {
+            SDLputPixelAlpha(mTarget, x, y, mColor);
+            
+        }
+        else
+        {
+            SDLputPixel(mTarget, x, y, mColor);
+        }*/
+        SDL_RenderDrawPoint(mRenderTarget, x, y);
+        restoreRenderColor();
+    }
+
+    void SDL2Graphics::drawHLine(int x1, int y, int x2)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+        const ClipRectangle& top = mClipStack.top();
+
+        x1 += top.xOffset;
+        y += top.yOffset;
+        x2 += top.xOffset;
+
+        if (y < top.y || y >= top.y + top.height)
+            return;
+
+        if (x1 > x2)
+        {
+            x1 ^= x2;
+            x2 ^= x1;
+            x1 ^= x2;
+        }
+
+        if (top.x > x1)
+        {
+            if (top.x > x2)
+            {
+                return;
+            }
+            x1 = top.x;
+        }
+
+        if (top.x + top.width <= x2)
+        {
+            if (top.x + top.width <= x1)
+            {
+                return;
+            }
+            x2 = top.x + top.width -1;
+        }
+
+        saveRenderColor();
+        SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+        SDL_RenderDrawLine(mRenderTarget, x1, y, x2, y); 
+        restoreRenderColor();
+    }
+
+    void SDL2Graphics::drawVLine(int x, int y1, int y2)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+        const ClipRectangle& top = mClipStack.top();
+
+        x += top.xOffset;
+        y1 += top.yOffset;
+        y2 += top.yOffset;
+
+        if (x < top.x || x >= top.x + top.width)
+            return;
+
+        if (y1 > y2)
+        {
+            y1 ^= y2;
+            y2 ^= y1;
+            y1 ^= y2;
+        }
+
+        if (top.y > y1)
+        {
+            if (top.y > y2)
+            {
+                return;
+            }
+            y1 = top.y;
+        }
+
+        if (top.y + top.height <= y2)
+        {
+            if (top.y + top.height <= y1)
+            {
+                return;
+            }
+            y2 = top.y + top.height - 1;
+        }
+
+        saveRenderColor();
+        SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+        SDL_RenderDrawLine(mRenderTarget, x, y1, x, y2);
+        restoreRenderColor();
+    }
+        
+    void SDL2Graphics::drawRectangle(const Rectangle& rectangle)
+    {
+        int x1 = rectangle.x;
+        int x2 = rectangle.x + rectangle.width - 1;
+        int y1 = rectangle.y;
+        int y2 = rectangle.y + rectangle.height - 1;
+
+        drawHLine(x1, y1, x2);
+        drawHLine(x1, y2, x2);
+
+        drawVLine(x1, y1, y2);
+        drawVLine(x2, y1, y2);
+    }
+
+    void SDL2Graphics::drawLine(int x1, int y1, int x2, int y2)
+    {
+        
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+        const ClipRectangle& top = mClipStack.top();
+
+        x1 += top.xOffset;
+        y1 += top.yOffset;
+        x2 += top.xOffset;
+        y2 += top.yOffset;
+
+        saveRenderColor();
+        SDL_SetRenderDrawColor(mRenderTarget, mColor.r, mColor.g, mColor.b, mColor.a);
+        SDL_RenderDrawLine(mRenderTarget, x1, y1, x2, y2); 
+        restoreRenderColor();
+    }
+
+    void SDL2Graphics::setColor(const Color& color)
+    {
+        mColor = color;
+
+        mAlpha = color.a != 255;
+    }
+
+    const Color& SDL2Graphics::getColor()
+    {
+        return mColor;
+    }
+
+    void SDL2Graphics::drawSDLSurface(SDL_Surface* surface, SDL_Rect source,
+                                     SDL_Rect destination)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+        const ClipRectangle& top = mClipStack.top();
+
+        destination.x += top.xOffset;
+        destination.y += top.yOffset;
+        destination.w = source.w;
+        destination.h = source.h;
+        SDL_Rect temp;
+        temp.x = 0;
+        temp.y = 0;
+        temp.w = source.w;
+        temp.h = source.h;
+
+        SDL_FillRect(mTarget, &temp, SDL_MapRGBA(mTarget->format, 0xff, 0, 0xff, 0));
+        SDL_BlitSurface(surface, &source, mTarget, &temp);
+        SDL_UpdateTexture(mTexture, &temp, mTarget->pixels, mTarget->pitch);
+        SDL_RenderCopy(mRenderTarget, mTexture, &temp, &destination);
+    }
+
+    void SDL2Graphics::drawSDLTexture(SDL_Texture * texture, SDL_Rect source, 
+                                      SDL_Rect destination)
+    {
+        if (mClipStack.empty()) {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+                "called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+        const ClipRectangle& top = mClipStack.top();
+
+        destination.x += top.xOffset;
+        destination.y += top.yOffset;
+        destination.w = source.w;
+        destination.h = source.h;
+
+        SDL_RenderCopy(mRenderTarget, texture, &source, &destination);
+    }
+    
+    void SDL2Graphics::saveRenderColor()
+    {
+        SDL_GetRenderDrawColor(mRenderTarget, &r, &g, &b, &a);
+    }
+    
+    void SDL2Graphics::restoreRenderColor()
+    {
+        SDL_SetRenderDrawColor(mRenderTarget, r, g, b, a);
+    }
+}

--- a/src/sdl/sdlgraphics.cpp
+++ b/src/sdl/sdlgraphics.cpp
@@ -79,6 +79,11 @@ namespace gcn
     {
         mAlpha = false;
     }
+	
+	SDLGraphics::~SDLGraphics()
+	{
+
+	}
 
     void SDLGraphics::_beginDraw()
     {
@@ -146,7 +151,7 @@ namespace gcn
     {
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
 
 	const ClipRectangle& top = mClipStack.top();
@@ -173,7 +178,7 @@ namespace gcn
     {
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
 
         const ClipRectangle& top = mClipStack.top();
@@ -223,7 +228,7 @@ namespace gcn
     {
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
 
         const ClipRectangle& top = mClipStack.top();
@@ -248,7 +253,7 @@ namespace gcn
     {
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
         const ClipRectangle& top = mClipStack.top();
 
@@ -359,7 +364,7 @@ namespace gcn
     {
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
         const ClipRectangle& top = mClipStack.top();
 
@@ -494,7 +499,7 @@ namespace gcn
 
 	if (mClipStack.empty()) {
 		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
+			"called a draw function outside of _beginDraw() and _endDraw()?");
 	}
         const ClipRectangle& top = mClipStack.top();
 
@@ -669,10 +674,10 @@ namespace gcn
     void SDLGraphics::drawSDLSurface(SDL_Surface* surface, SDL_Rect source,
                                      SDL_Rect destination)
     {
-	if (mClipStack.empty()) {
-		throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
-			"called a draw funtion outside of _beginDraw() and _endDraw()?");
-	}
+		if (mClipStack.empty()) {
+			throw GCN_EXCEPTION("Clip stack is empty, perhaps you"
+				"called a draw function outside of _beginDraw() and _endDraw()?");
+		}
         const ClipRectangle& top = mClipStack.top();
 
         destination.x += top.xOffset;

--- a/src/sdl/sdlimage.cpp
+++ b/src/sdl/sdlimage.cpp
@@ -65,10 +65,16 @@
 
 namespace gcn
 {
-    SDLImage::SDLImage(SDL_Surface* surface, bool autoFree)
+    SDLImage::SDLImage(SDL_Surface* surface, bool autoFree, SDL_Renderer* renderer)
     {
         mAutoFree = autoFree;
         mSurface = surface;
+		mRenderer = renderer;
+		if (renderer)
+		{
+			mTexture = SDL_CreateTextureFromSurface(renderer, surface);
+			SDL_SetTextureBlendMode(mTexture, SDL_BLENDMODE_BLEND);
+		}       
     }
 
     SDLImage::~SDLImage()
@@ -83,6 +89,11 @@ namespace gcn
     {
         return mSurface;
     }
+    
+    SDL_Texture* SDLImage::getTexture() const
+    {
+		return mTexture;
+	}
 
     int SDLImage::getWidth() const
     {
@@ -174,10 +185,20 @@ namespace gcn
             SDL_SetSurfaceAlphaMod(tmp, 255);
 
         mSurface = tmp;
+
+		if (mRenderer)
+		{
+			SDL_Texture *tmpTexture = SDL_CreateTextureFromSurface(mRenderer, tmp);
+			SDL_SetTextureBlendMode(tmpTexture, SDL_BLENDMODE_BLEND);
+			SDL_DestroyTexture(mTexture);
+			mTexture = tmpTexture;
+		}
+		
     }
 
     void SDLImage::free()
     {
         SDL_FreeSurface(mSurface);
+        SDL_DestroyTexture(mTexture);
     }
 }

--- a/src/sdl/sdlimageloader.cpp
+++ b/src/sdl/sdlimageloader.cpp
@@ -87,7 +87,7 @@ namespace gcn
                     std::string("Not enough memory to load: ") + filename);
         }
 
-        Image *image = new SDLImage(surface, true);
+        Image *image = new SDLImage(surface, true, mRenderer);
 
         if (convertToDisplayFormat)
         {
@@ -96,10 +96,20 @@ namespace gcn
 
         return image;
     }
+    
+    void SDLImageLoader::setRenderer(SDL_Renderer* renderer)
+    {
+		mRenderer = renderer;
+	}
 
     SDL_Surface* SDLImageLoader::loadSDLSurface(const std::string& filename)
     {
         return IMG_Load(filename.c_str());
+    }
+    
+    SDL_Texture* SDLImageLoader::loadSDLTexture(const std::string& filename)
+    {
+        return IMG_LoadTexture(mRenderer, filename.c_str());
     }
 
     SDL_Surface* SDLImageLoader::convertToStandardFormat(SDL_Surface* surface)

--- a/src/sdl/sdltruetypefont.cpp
+++ b/src/sdl/sdltruetypefont.cpp
@@ -51,6 +51,7 @@
 #include "guisan/image.hpp"
 #include "guisan/graphics.hpp"
 #include "guisan/sdl/sdlgraphics.hpp"
+#include "guisan/sdl/sdl2graphics.hpp"
 
 namespace gcn
 {
@@ -96,8 +97,10 @@ namespace gcn
 		}
 	
 		gcn::SDLGraphics *sdlGraphics = dynamic_cast<gcn::SDLGraphics *>(graphics);
+		gcn::SDL2Graphics *sdl2Graphics = dynamic_cast<gcn::SDL2Graphics *>(graphics);
+		
 
-		if (sdlGraphics == NULL)
+		if (sdlGraphics == NULL && sdl2Graphics == NULL)
 		{
 			throw GCN_EXCEPTION("SDLTrueTypeFont::drawString. Graphics object not an SDL graphics object!");
 			return;
@@ -106,7 +109,15 @@ namespace gcn
 		// This is needed for drawing the Glyph in the middle if we have spacing
 		int yoffset = getRowSpacing() / 2;
 	
-		Color col = sdlGraphics->getColor();
+		Color col;
+		if (sdlGraphics)
+		{
+			col = sdlGraphics->getColor();
+		}
+		else
+		{
+			col = sdl2Graphics->getColor();
+		}
 
 		SDL_Color sdlCol;
 		sdlCol.b = col.b;
@@ -130,8 +141,18 @@ namespace gcn
 		src.h = textSurface->h;
 		src.x = 0;
 		src.y = 0;
+		dst.w = src.w;
+		dst.h = src.h;
 	
-		sdlGraphics->drawSDLSurface(textSurface, src, dst);
+		if (sdlGraphics)
+		{
+			sdlGraphics->drawSDLSurface(textSurface, src, dst);
+		}
+		else
+		{
+			sdl2Graphics->drawSDLSurface(textSurface, src, dst);
+		}
+		
 		SDL_FreeSurface(textSurface);        
 	}
 


### PR DESCRIPTION
The long awaited SDL2Graphics is now there! To summarize, it adds support of textures and renderers (introduced in SDL2) instead of relying solely on surfaces. Performance gains are likely.  
A new example file, `sdl2widgets.cpp` has also been added to demonstrate usage of this new Graphics implementation.

You may want to check by running the example that the colors are correct; I ran into some issues on my machine, but I am not sure that the fix will work everywhere. 