### PR TITLE
Handle "special" characters in SDLInput:

### DIFF
--- a/include/guisan/key.hpp
+++ b/include/guisan/key.hpp
@@ -97,6 +97,13 @@ namespace gcn
         bool isLetter() const;
 
         /**
+         * Checks whether a key is printable.
+         *
+         * @return true if the key is a printable.
+         */
+        bool isPrintable() const;
+
+        /**
          * Gets the value of the key. If an ascii value exists it will be
          * returned. Otherwise an enum value will be returned.
          *

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -87,6 +87,11 @@ namespace gcn
                 && (mValue != 215) && (mValue != 247));
     }
 
+    bool Key::isPrintable() const
+    {
+        return 0 < mValue && mValue < 1000;
+    }
+
     int Key::getValue() const
     {
         return mValue;

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -349,8 +349,8 @@ namespace gcn
             mCaretColumn += 4;
         }
 
-        else if (key.isCharacter()
-                 && mEditable)
+        else if (key.isCharacter() && mEditable && !keyEvent.isAltPressed()
+                 && !keyEvent.isControlPressed())
         {
             if(keyEvent.isShiftPressed() && key.isLetter())
             {
@@ -358,7 +358,7 @@ namespace gcn
             }
             else
             {
-                mTextRows[mCaretRow].insert(mCaretColumn,std::string(1,key.getChar()));
+                mTextRows[mCaretRow].insert(mCaretColumn,std::string(1,(char)key.getValue()));
             }
             ++mCaretColumn;
         }

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -209,8 +209,8 @@ namespace gcn
             mCaretPosition = mText.size();
         }
 
-        else if (key.isCharacter()
-            && key.getValue() != Key::TAB)
+        else if (key.isCharacter() && key.getValue() != Key::TAB && !keyEvent.isAltPressed()
+                 && !keyEvent.isControlPressed())
         {
             if (keyEvent.isShiftPressed() && key.isLetter())
             {


### PR DESCRIPTION
- Allow to get characters which share keys 0-9 (with shift or alt-gr).
- Handle shift for non-alphabetic characters (as ;: )
- get "upper" value when caplock is on.

Widget:
- TextBox and TextField no longer display character when alt/ctrl is pressed so not-handled combination (`ctrl+v`/`ctrl+a`) won't print the character. so `shift+3` would only display alternative character.