### PR TITLE
Apply guichan's change 8565f3e8ce86c771551dadc2d91cf883d7f9d917 (dec 22th 2007)

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Continue rebasing from 8565f3e8ce86c771551dadc2d91cf883d7f9d917
+* Continue rebasing from 753608c0c8cd0196c19c467db0f8df5f61d99b3c
 * Add a focus listener interface.
 * Make focus apply synchronously.
 * Graphics and input objects for DirectX.

--- a/include/guisan/graphics.hpp
+++ b/include/guisan/graphics.hpp
@@ -101,6 +101,16 @@ namespace gcn
     class GCN_CORE_DECLSPEC Graphics
     {
     public:
+        /**
+         * Alignments for text drawing.
+         */
+        enum Alignment
+        {
+            LEFT = 0,
+            CENTER,
+            RIGHT
+        };
+
         Graphics();
 
         virtual ~Graphics() { }
@@ -254,16 +264,7 @@ namespace gcn
          * @throws Exception when no Font is set.
          */
         virtual void drawText(const std::string& text, int x, int y,
-                              unsigned int alignment = LEFT);
-        /**
-         * Alignments for text drawing.
-         */
-        enum
-        {
-            LEFT = 0,
-            CENTER,
-            RIGHT
-        };
+                              Alignment alignment = LEFT);
 
     protected:
         std::stack<ClipRectangle> mClipStack;

--- a/include/guisan/widget.hpp
+++ b/include/guisan/widget.hpp
@@ -81,7 +81,7 @@ namespace gcn
 
     /**
      * Widget base class. Contains basic widget functions every widget should
-     * have. Widgets should inherit from this class and implements it's
+     * have. Widgets should inherit from this class and implements its
      * functions.
      *
      * NOTE: Functions begining with underscore "_" should not
@@ -179,35 +179,35 @@ namespace gcn
         void setSize(int width, int height);
 
         /**
-         * Set the widget x coordinate. It is relateive to it's parent.
+         * Set the widget x coordinate. It is relateive to its parent.
          *
          * @param x the widget x coordinate.
          */
         void setX(int x);
 
         /**
-         * Gets the widget x coordinate. It is relative to it's parent.
+         * Gets the widget x coordinate. It is relative to its parent.
          *
          * @return the widget x coordinate.
          */
         int getX() const;
 
         /**
-         * Set the widget y coordinate. It is relative to it's parent.
+         * Set the widget y coordinate. It is relative to its parent.
          *
          * @param y the widget y coordinate.
          */
         void setY(int y);
 
         /**
-         * Gets the widget y coordinate. It is relative to it's parent.
+         * Gets the widget y coordinate. It is relative to its parent.
          *
          * @return the widget y coordinate.
          */
         int getY() const;
 
         /**
-         * Sets the widget position. It is relative to it's parent.
+         * Sets the widget position. It is relative to its parent.
          *
          * @param x the widget x coordinate.
          * @param y the widgets y coordinate.
@@ -215,7 +215,7 @@ namespace gcn
         void setPosition(int x, int y);
 
         /**
-         * Sets the dimension of the widget. It is relative to it's parent.
+         * Sets the dimension of the widget. It is relative to its parent.
          *
          * @param dimension the widget dimension.
          */
@@ -242,7 +242,7 @@ namespace gcn
         unsigned int getBorderSize() const;
 
         /**
-         * Gets the dimension of the widget. It is relative to it's parent.
+         * Gets the dimension of the widget. It is relative to its parent.
          *
          * @return the widget dimension.
          */
@@ -611,7 +611,7 @@ namespace gcn
 
         /**
          * Requests modal focus. When a widget has modal focus, only that
-         * widget and it's children may recieve input.
+         * widget and its children may recieve input.
          *
          * @throws Exception if another widget already has modal focus.
          */
@@ -642,12 +642,12 @@ namespace gcn
         virtual void releaseModalMouseInputFocus();
 
         /**
-         * Checks if the widget or it's parent has modal focus.
+         * Checks if the widget or its parent has modal focus.
          */
         virtual bool hasModalFocus() const;
 
         /**
-         * Checks if the widget or it's parent has modal mouse input focus.
+         * Checks if the widget or its parent has modal mouse input focus.
          *
          * @since 0.6.0
          */

--- a/include/guisan/widgets/button.hpp
+++ b/include/guisan/widgets/button.hpp
@@ -61,6 +61,7 @@
 
 #include "guisan/focuslistener.hpp"
 #include "guisan/keylistener.hpp"
+#include "guisan/graphics.hpp"
 #include "guisan/mouseevent.hpp"
 #include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
@@ -109,22 +110,22 @@ namespace gcn
         const std::string& getCaption() const;
 
         /**
-         * Sets the alignment for the caption.
+         * Sets the alignment of the caption.
          *
-         * @param alignment Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT
+         * @param alignment The alignment of the caption.
          * @see Graphics
          */
-        void setAlignment(unsigned int alignment);
+        void setAlignment(Graphics::Alignment alignment);
 
         /**
-         * Gets the alignment for the caption.
+         * Gets the alignment of the caption.
          *
          * @return alignment of caption.
          */
-        unsigned int getAlignment() const;
+        Graphics::Alignment getAlignment() const;
 
         /**
-         * Sets the spacing between the border of this button and its caption.
+         * Sets the spacing between the border of the button and its caption.
          *
          * @param spacing is a number between 0 and 255. The default value for 
                           spacing is 4 and can be changed using this method.
@@ -132,7 +133,7 @@ namespace gcn
         void setSpacing(unsigned int spacing);
 
         /**
-         * Gets the spacing between the border of this button and its caption.
+         * Gets the spacing between the border of the button and its caption.
          *
          * @return spacing.
          */
@@ -142,13 +143,6 @@ namespace gcn
          * Adjusts the buttons size to fit the content.
          */
         void adjustSize();
-
-        /**
-         * Checks if the button is pressed down. Useful when drawing.
-         *
-         * @return true if the button is pressed down.
-         */
-        bool isPressed() const;
 
 
         //Inherited from Widget
@@ -183,11 +177,42 @@ namespace gcn
         virtual void keyReleased(KeyEvent& keyEvent);
 
     protected:
+        /**
+         * Checks if the button is pressed. Convenient method to use
+         * when overloading the draw method of the button.
+         *
+         * @return True if the button is pressed, false otherwise.
+         */
+        bool isPressed() const;
+
+        /**
+         * Holds the caption of the button.
+         */
         std::string mCaption;
+
+        /**
+         * True if the mouse is ontop of the button, false otherwise.
+         */
         bool mHasMouse;
+
+        /**
+         * True if a key has been pressed, false otherwise.
+         */
         bool mKeyPressed;
+
+        /**
+         * True if a mouse has been pressed, false otherwise.
+         */
         bool mMousePressed;
-        unsigned int mAlignment;
+
+        /**
+         * Holds the alignment of the caption.
+         */
+        Graphics::Alignment mAlignment;
+
+        /**
+         * Holds the spacing between the border and the caption.
+         */
         unsigned int mSpacing;
     };
 }

--- a/include/guisan/widgets/checkbox.hpp
+++ b/include/guisan/widgets/checkbox.hpp
@@ -88,7 +88,7 @@ namespace gcn
 
         /**
          * Constructor. The check box will be automatically resized
-         * to fit it's caption.
+         * to fit the caption.
          *
          * @param caption The caption of the check box.
          * @param marked True if the check box is selected, false otherwise.
@@ -109,7 +109,7 @@ namespace gcn
         bool isSelected() const;
 
         /**
-         * Sets the check box to be selected.
+         * Sets the check box to be selected or not.
          *
          * @param selected True if the check box should be set as selected.
          * @see isSelected

--- a/include/guisan/widgets/container.hpp
+++ b/include/guisan/widgets/container.hpp
@@ -92,12 +92,12 @@ namespace gcn
 
         /**
          * Sets the container to be opaque or not. If the container
-         * is opaque it's background will be drawn, if it's not opaque 
-         * it's background will not be drawn, and thus making the container
+         * is opaque its background will be drawn, if it's not opaque
+         * its background will not be drawn, and thus making the container
          * completely transparent.
          *
          * NOTE: This is not the same as to set visibility. A non visible
-         *       container will not itself nor will it draw it's content.
+         *       container will not itself nor will it draw its content.
          *
          * @param opaque True if the container should be opaque, false otherwise.
          * @see isOpaque

--- a/include/guisan/widgets/dropdown.hpp
+++ b/include/guisan/widgets/dropdown.hpp
@@ -150,7 +150,7 @@ namespace gcn
         /**
          * Adjusts the height of the drop down to fit the height of the
          * drop down's parent's height. It's used to not make the drop down
-         * draw itself outside of it's parent if folded down.
+         * draw itself outside of its parent if folded down.
          */
         void adjustHeight();
 

--- a/include/guisan/widgets/label.hpp
+++ b/include/guisan/widgets/label.hpp
@@ -59,6 +59,7 @@
 
 #include <string>
 
+#include "guisan/graphics.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
 
@@ -76,7 +77,8 @@ namespace gcn
         Label();
 
         /**
-         * Constructor.
+         * Constructor. The label will be automatically resized
+         * to fit the caption.
          *
          * @param caption The caption of the label.
          */
@@ -101,25 +103,25 @@ namespace gcn
         void setCaption(const std::string& caption);
 
         /**
-         * Sets the alignment for the caption. The alignment is relative
+         * Sets the alignment of the caption. The alignment is relative
          * to the center of the label.
          *
-         * @param alignemnt Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @param alignemnt The alignment of the caption of the label.
          * @see getAlignment, Graphics
          */
-        void setAlignment(unsigned int alignment);
+        void setAlignment(Graphics::Alignment alignment);
 
         /**
-         * Gets the alignment for the caption. The alignment is relative to
+         * Gets the alignment of the caption. The alignment is relative to
          * the center of the label.
          *
-         * @return alignment of caption. Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @return The alignment of caption of the label.
          * @see setAlignment, Graphics
          */
-        unsigned int getAlignment() const;
+        Graphics::Alignment getAlignment() const;
 
         /**
-         * Adjusts the label's size to fit the caption size.
+         * Adjusts the label's size to fit the caption.
          */
         void adjustSize();
 
@@ -139,7 +141,7 @@ namespace gcn
         /**
          * Holds the alignment of the caption.
          */
-        unsigned int mAlignment;
+        Graphics::Alignment mAlignment;
     };
 }
 

--- a/include/guisan/widgets/listbox.hpp
+++ b/include/guisan/widgets/listbox.hpp
@@ -137,7 +137,7 @@ namespace gcn
         ListModel *getListModel();
 
         /**
-         * Adjusts the size of the list box to fit it's list model.
+         * Adjusts the size of the list box to fit its list model.
          */
         void adjustSize();
 

--- a/include/guisan/widgets/messagebox.hpp
+++ b/include/guisan/widgets/messagebox.hpp
@@ -59,6 +59,7 @@
 
 #include <string>
 
+#include "guisan/graphics.hpp"
 #include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widgets/window.hpp"
@@ -121,32 +122,18 @@ namespace gcn
         const std::string& getCaption() const;
 
         /**
-         * Sets the alignment for the caption.
-         *
-         * @param alignment Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
-         */
-        void setAlignment(unsigned int alignment);
-
-        /**
-         * Gets the alignment for the caption.
-         *
-         * @return alignment of caption.
-         */
-        unsigned int getAlignment() const;
-        
-        /**
          * Sets the position for the button(s) in the MessageBox.
          *
-         * @param alignment Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @param alignment The alignment of the button(s).
          */
-        void setButtonAlignment(unsigned int alignment);
+        void setButtonAlignment(Graphics::Alignment alignment);
 
         /**
          * Gets the position for the button(s) in the MessageBox.
          *
          * @return alignment of buttons.
          */
-        unsigned int getButtonAlignment() const;
+        Graphics::Alignment getButtonAlignment() const;
 
         /**
          * Sets the padding of the window which is the distance between the
@@ -236,7 +223,7 @@ namespace gcn
     protected:
         std::string mMessage;
         int mNbButtons;
-        unsigned int mButtonAlignment;
+        Graphics::Alignment mButtonAlignment;
         int mClickedButton;
         
         Button **mButtons;

--- a/include/guisan/widgets/progressbar.hpp
+++ b/include/guisan/widgets/progressbar.hpp
@@ -59,6 +59,7 @@
 
 #include <string>
 
+#include "guisan/graphics.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
 #include "guisan/widgets/label.hpp"
@@ -117,20 +118,20 @@ namespace gcn
          * Sets the alignment for the caption. The alignment is relative
          * to the center of the label.
          *
-         * @param alignemnt Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @param alignemnt The alignment of the caption.
          * @see getAlignment, Graphics
          */
-        void setAlignment(unsigned int alignment);
+        void setAlignment(Graphics::Alignment alignment);
 
         /**
          * Gets the alignment for the caption. The alignment is relative to
          * the center of the label.
          *
-         * @return alignment of caption. Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @return The alignment of the caption.
          * @see setAlignment, Graphics
          */
-        unsigned int getAlignment() const;
-        
+        Graphics::Alignment getAlignment() const;
+
         /**
          * Sets the minimum value.
          *
@@ -200,7 +201,7 @@ namespace gcn
         /**
          * Holds the alignment of the caption.
          */
-        unsigned int mAlignment;
+        Graphics::Alignment mAlignment;
         
         unsigned int mStart; //! minimum value of the progressbar
         unsigned int mEnd;   //! maximum value of the progressbar

--- a/include/guisan/widgets/radiobutton.hpp
+++ b/include/guisan/widgets/radiobutton.hpp
@@ -68,7 +68,7 @@
 namespace gcn
 {
     /**
-     * Implementation of a radio button where a user can select or deselect
+     * An implementation of a radio button where a user can select or deselect
      * the radio button and where the status of the radio button is displayed to the user.
      * A radio button can belong to a group and when a radio button belongs to a
      * group only one radio button can be selected in the group. A radio button is
@@ -90,7 +90,8 @@ namespace gcn
         RadioButton();
 
         /**
-         * Constructor.
+         * Constructor. The radio button will be automatically resized
+         * to fit the caption.
          *
          * @param caption The caption of the radio button.
          * @param group The group the radio button should belong to.

--- a/include/guisan/widgets/scrollarea.hpp
+++ b/include/guisan/widgets/scrollarea.hpp
@@ -79,6 +79,21 @@ namespace gcn
         public MouseListener
     {
     public:
+        /**
+         * Scrollpolicies for the horizontal and vertical scrollbar.
+         * The policies are:
+         *
+         * SHOW_ALWAYS - Always show the scrollbars no matter what.
+         * SHOW_NEVER  - Never show the scrollbars no matter waht.
+         * SHOW_AUTO   - Show the scrollbars only when needed. That is if the
+         *               content grows larger then the ScrollArea.
+         */
+        enum ScrollPolicy
+        {
+            SHOW_ALWAYS = 0,
+            SHOW_NEVER,
+            SHOW_AUTO
+        };
 
         /**
          * Constructor.
@@ -101,7 +116,7 @@ namespace gcn
          * @param vPolicy the policy for the vertical scrollbar. See enum with
          *                policies.
          */
-        ScrollArea(Widget *content, unsigned int hPolicy, unsigned int vPolicy);
+        ScrollArea(Widget *content, ScrollPolicy hPolicy, ScrollPolicy vPolicy);
 
         /**
          * Destructor.
@@ -123,46 +138,40 @@ namespace gcn
         Widget* getContent();
 
         /**
-         * Sets the horizontal scrollbar policy. See enum with policies.
+         * Sets the horizontal scrollbar policy.
          *
-         * @param hPolicy the policy for the horizontal scrollbar. See enum with
-         *                policies.
+         * @param hPolicy the policy for the horizontal scrollbar.
          */
-        void setHorizontalScrollPolicy(unsigned int hPolicy);
+        void setHorizontalScrollPolicy(ScrollPolicy hPolicy);
 
         /**
-         * Gets the horizontal scrollbar policy. See enum with policies.
+         * Gets the horizontal scrollbar policy.
          *
-         * @return the policy for the horizontal scrollbar policy. See enum with
-         *         policies.
+         * @return the policy for the horizontal scrollbar policy.
          */
-        unsigned int getHorizontalScrollPolicy() const;
+        ScrollPolicy getHorizontalScrollPolicy() const;
 
         /**
-         * Sets the vertical scrollbar policy. See enum with policies.
+         * Sets the vertical scrollbar policy.
          *
-         * @param vPolicy the policy for the vertical scrollbar. See enum with
-         *                policies.
+         * @param vPolicy the policy for the vertical scrollbar.
          */
-        void setVerticalScrollPolicy(unsigned int vPolicy);
+        void setVerticalScrollPolicy(ScrollPolicy vPolicy);
 
         /**
-         * Gets the vertical scrollbar policy. See enum with policies.
+         * Gets the vertical scrollbar policy.
          *
-         * @return the policy for the vertical scrollbar. See enum with
-         *         policies.
+         * @return the policy for the vertical scrollbar.
          */
-        unsigned int getVerticalScrollPolicy() const;
+        ScrollPolicy getVerticalScrollPolicy() const;
 
         /**
-         * Sets the horizontal and vertical scrollbar policy. See enum with policies.
+         * Sets the horizontal and vertical scrollbar policy.
          *
-         * @param hPolicy the policy for the horizontal scrollbar. See enum with
-         *                policies.
-         * @param vPolicy the policy for the vertical scrollbar. See enum with
-         *                policies.
+         * @param hPolicy the policy for the horizontal scrollbar.
+         * @param vPolicy the policy for the vertical scrollbar.
          */
-        void setScrollPolicy(unsigned int hPolicy, unsigned int vPolicy);
+        void setScrollPolicy(ScrollPolicy hPolicy, ScrollPolicy vPolicy);
 
         /**
          * Sets the amount to scroll vertically.
@@ -321,22 +330,6 @@ namespace gcn
         virtual void mouseWheelMovedDown(MouseEvent& mouseEvent);
 
 
-        /**
-         * Scrollpolicies for the horizontal and vertical scrollbar.
-         * The policies are:
-         *
-         * SHOW_ALWAYS - Always show the scrollbars no matter what.
-         * SHOW_NEVER  - Never show the scrollbars no matter waht.
-         * SHOW_AUTO   - Show the scrollbars only when needed. That is if the
-         *               content grows larger then the ScrollArea.
-         */
-        enum
-        {
-            SHOW_ALWAYS,
-            SHOW_NEVER,
-            SHOW_AUTO
-        };
-
     protected:
         /**
          * Draws the background of the ScrollArea
@@ -463,24 +456,99 @@ namespace gcn
          */
         Rectangle getHorizontalMarkerDimension();
 
+        /**
+         * Holds the vertical scroll amount.
+         */
         int mVScroll;
+
+        /**
+         * Holds the horizontal scroll amount.
+         */
         int mHScroll;
+
+        /**
+         * Holds the width of the scroll bars.
+         */
         int mScrollbarWidth;
-        unsigned int mHPolicy;
-        unsigned int mVPolicy;
+
+        /**
+         * Holds the horizontal scroll bar policy.
+         */
+        ScrollPolicy mHPolicy;
+
+        /**
+         * Holds the vertical scroll bar policy.
+         */
+        ScrollPolicy mVPolicy;
+
+        /**
+         * True if the vertical scroll bar is visible, false otherwise.
+         */
         bool mVBarVisible;
+
+        /**
+         * True if the horizontal scroll bar is visible, false otherwise.
+         */
         bool mHBarVisible;
+
+        /**
+         * True if the up button is pressed, false otherwise.
+         */
         bool mUpButtonPressed;
+
+        /**
+         * True if the down button is pressed, false otherwise.
+         */
         bool mDownButtonPressed;
+
+        /**
+         * True if the left button is pressed, false otherwise.
+         */
         bool mLeftButtonPressed;
+
+        /**
+         * True if the right button is pressed, false otherwise.
+         */
         bool mRightButtonPressed;
+
+        /**
+         * Holds the up button scroll amount.
+         */
         int mUpButtonScrollAmount;
+
+        /**
+         * Holds the down button scroll amount.
+         */
         int mDownButtonScrollAmount;
+
+        /**
+         * Holds the left button scroll amount.
+         */
         int mLeftButtonScrollAmount;
+
+        /**
+         * Holds the right button scroll amount.
+         */
         int mRightButtonScrollAmount;
+
+        /**
+         * True if the vertical marked is dragged.
+         */
         bool mIsVerticalMarkerDragged;
+
+        /**
+         * True if the horizontal marked is dragged.
+         */
         bool mIsHorizontalMarkerDragged;
+
+        /**
+         * Holds the horizontal markers drag offset.
+         */
         int mHorizontalMarkerDragOffset;
+
+        /**
+         * Holds the vertical markers drag offset.
+         */
         int mVerticalMarkerDragOffset;
     };
 }

--- a/include/guisan/widgets/slider.hpp
+++ b/include/guisan/widgets/slider.hpp
@@ -65,9 +65,11 @@
 namespace gcn
 {
     /**
-     * A slider able to slide between different values. You can set the scale
-     * of the slider yourself so that it ranges between, for example, -1.0 and
-     * 2.0.
+     * An implementation of a slider where a user can select different values by
+     * sliding between a start value and an end value of a scale.
+     *
+     * If the selected value is changed an action event will be sent to all
+     * action listeners of the slider.
      */
     class GCN_CORE_DECLSPEC Slider :
         public Widget,
@@ -75,19 +77,28 @@ namespace gcn
         public KeyListener
     {
     public:
+        /**
+         * Draw orientations for the slider. A slider can be drawn vertically or
+         * horizontally.
+         */
+        enum Orientation
+        {
+            HORIZONTAL = 0,
+            VERTICAL
+        };
 
         /**
-         * Constructor. Scale start is 0.
+         * Constructor. The default start value of the slider scale is zero.
          *
-         * @param scaleEnd the end of the slider scale.
+         * @param scaleEnd The end value of the slider scale.
          */
         Slider(double scaleEnd = 1.0);
 
         /**
          * Constructor.
          *
-         * @param scaleStart the start of the scale.
-         * @param scaleEnd the end of the scale.
+         * @param scaleStart The start value of the slider scale.
+         * @param scaleEnd The end value of the slider scale.
          */
         Slider(double scaleStart, double scaleEnd);
 
@@ -97,112 +108,120 @@ namespace gcn
         virtual ~Slider() { }
 
         /**
-         * Sets the scale.
+         * Sets the scale of the slider.
          *
-         * @param scaleStart the start of the scale.
-         * @param scaleEnd the end of the scale.
+         * @param scaleStart The start value of the scale.
+         * @param scaleEnd tThe end of value the scale.
+         * @see getScaleStart, getScaleEnd
          */
         void setScale(double scaleStart, double scaleEnd);
 
         /**
-         * Gets the scale start.
+         * Gets the start value of the scale.
          *
-         * @return the scale start.
+         * @return The start value of the scale.
+         * @see setScaleStart, setScale
          */
         double getScaleStart() const;
 
         /**
-         * Sets the scale start.
+         * Sets the start value of the scale.
          *
-         * @param scaleStart the start of the scale.
+         * @param scaleStart The start value of the scale.
+         * @see getScaleStart
          */
         void setScaleStart(double scaleStart);
 
         /**
-         * Gets the scale end.
+         * Gets the end value of the scale.
          *
-         * @return the scale end.
+         * @return The end value of the scale.
+         * @see setScaleEnd, setScale
          */
         double getScaleEnd() const;
 
         /**
-         * Sets the scale end.
+         * Sets the end value of the scale.
          *
-         * @param scaleEnd the end of the scale.
+         * @param scaleEnd The end value of the scale.
+         * @see getScaleEnd
          */
         void setScaleEnd(double scaleEnd);
 
         /**
-         * Gets the current value.
+         * Gets the current selected value.
          *
-         * @return the current value.
+         * @return The current selected value.
+         * @see setValue
          */
         double getValue() const;
 
         /**
-         * Sets the current value.
+         * Sets the current selected value.
          *
-         * @param value a scale value.
+         * @param value The current selected value.
+         * @see getValue
          */
         void setValue(double value);
 
         /**
-         * Draws the marker.
-         *
-         * @param graphics a graphics object to draw with.
-         */
-        virtual void drawMarker(gcn::Graphics* graphics);
-
-        /**
          * Sets the length of the marker.
          *
-         * @param length new length for the marker.
+         * @param length The length for the marker.
+         * @see getMarkerLength
          */
         void setMarkerLength(int length);
 
         /**
          * Gets the length of the marker.
          *
-         * @return the length of the marker.
+         * @return The length of the marker.
+         * @see setMarkerLength
          */
         int getMarkerLength() const;
 
         /**
-         * Sets the orientation of the slider. A slider can be drawn verticaly
-         * or horizontaly. For orientation, see the enum in this class.
+         * Sets the orientation of the slider. A slider can be drawn vertically
+         * or horizontally.
          *
-         * @param orientation the orientation.
+         * @param orientation The orientation of the slider.
+         * @see getOrientation
          */
-        void setOrientation(unsigned int orientation);
+        void setOrientation(Orientation orientation);
 
         /**
-         * Gets the orientation of the slider. Se the enum in this class.
+         * Gets the orientation of the slider. A slider can be drawn vertically
+         * or horizontally.
          *
-         * @return the orientation of the slider.
+         * @return The orientation of the slider.
+         * @see setOrientation
          */
-        unsigned int getOrientation() const;
+        Orientation getOrientation() const;
 
         /**
-         * Sets the step length. Step length is used when the keys left and
-         * right are pressed.
+         * Sets the step length. The step length is used when the keys LEFT 
+         * and RIGHT are pressed to step in the scale.
          *
-         * @param length the step length.
+         * @param length The step length.
+         * @see getStepLength
          */
         void setStepLength(double length);
 
         /**
-         * Gets the step length.
+         * Gets the step length. The step length is used when the keys LEFT 
+         * and RIGHT are pressed to step in the scale.
          *
          * @return the step length.
+         * @see setStepLength
          */
         double getStepLength() const;
 
 
         // Inherited from Widget
 
-        virtual void draw(gcn::Graphics* graphics);
+        virtual void draw(Graphics* graphics);
 
-        virtual void drawBorder(gcn::Graphics* graphics);
+        virtual void drawBorder(Graphics* graphics);
 
 
         // Inherited from MouseListener.
@@ -220,47 +239,75 @@ namespace gcn
 
         virtual void keyPressed(KeyEvent& keyEvent);
 
-        /**
-         * Draw orientations for the slider. It can be drawn verticaly or
-         * horizontaly.
-         */
-        enum
-        {
-            HORIZONTAL = 0,
-            VERTICAL
-        };
-
     protected:
         /**
-         * Converts a marker position to a value.
+         * Draws the marker.
          *
-         * @param v the position to convert.
-         * @return the value corresponding to the position.
+         * @param graphics A graphics object to draw with.
          */
-        virtual double markerPositionToValue(int v) const;
+        virtual void drawMarker(Graphics* graphics);
+
+        /**
+         * Converts a marker position to a value in the scale.
+         *
+         * @param position The position to convert.
+         * @return A scale value corresponding to the position.
+         * @see valueToMarkerPosition
+         */
+        virtual double markerPositionToValue(int position) const;
 
         /**
          * Converts a value to a marker position.
          *
-         * @param value the value to convert.
-         * @return the position corresponding to the value.
+         * @param value The value to convert.
+         * @return A marker position corresponding to the value.
+         * @see markerPositionToValue
          */
         virtual int valueToMarkerPosition(double value) const;
 
         /**
-         * Gets the marker position for the current value.
+         * Gets the marker position of the current selected value.
          *
-         * @return the marker position for the current value.
+         * @return The marker position of the current selected value.
          */
         virtual int getMarkerPosition() const;
 
-        bool mMouseDrag;
+        /**
+         * True if the slider is dragged, false otherwise.
+         */
+        bool mDragged;
+
+        /**
+         * Holds the current selected value.
+         */
         double mValue;
+
+        /**
+         * Holds the step length. The step length is used when the keys LEFT 
+         * and RIGHT are pressed to step in the scale.
+         */
         double mStepLength;
+
+        /**
+         * Holds the length of the marker.
+         */
         int mMarkerLength;
+
+        /**
+         * Holds the start value of the scale.
+         */
         double mScaleStart;
+
+        /**
+         * Holds the end value of the scale.
+         */
         double mScaleEnd;
-        unsigned int mOrientation;
+
+        /**
+         * Holds the orientation of the slider. A slider can be drawn 
+         * vertically or horizontally.
+         */
+        Orientation mOrientation;
     };
 }
 

--- a/include/guisan/widgets/tab.hpp
+++ b/include/guisan/widgets/tab.hpp
@@ -68,9 +68,11 @@ namespace gcn
 {
     class Label;
     class TabbedArea;
-    
+
     /**
-     * A simple tab widget used as the default tab in the TabbedArea widget.
+     * An implementation of a simple tab to be used in a tabbed area.
+     *
+     * @see TabbedArea
      */
     class GCN_CORE_DECLSPEC Tab:
         public BasicContainer,
@@ -89,7 +91,7 @@ namespace gcn
         virtual ~Tab();
 
         /**
-         * Adjusts the tab size to fit the label.
+         * Adjusts the size of the tab fit the caption.
          */
         void adjustSize();
 
@@ -97,6 +99,7 @@ namespace gcn
          * Sets the tabbed area the tab should be a part of.
          *
          * @param tabbedArea The tabbed area the tab should be a part of.
+         * @see getTabbedArea
          */
         void setTabbedArea(TabbedArea* tabbedArea);
 
@@ -104,13 +107,17 @@ namespace gcn
          * Gets the tabbed are the tab is a part of.
          *
          * @return The tabbed are the tab is a part of.
+         * @see setTabbedArea
          */
         TabbedArea* getTabbedArea();
 
         /**
-         * Sets the caption of the tab.
+         * Sets the caption of the tab. It's advisable to call
+         * adjustSize after setting the caption to make the tab
+         * fit the caption.
          *
-         * @param caption The caption of the tab.         
+         * @param caption The caption of the tab.
+         * @see getCaption, adjustSize
          */
         void setCaption(const std::string& caption);
 
@@ -118,6 +125,7 @@ namespace gcn
          * Gets the caption of the tab.
          *
          * @return The caption of the tab.
+         * @see setCaption
          */
         const std::string& getCaption() const;
 
@@ -136,9 +144,24 @@ namespace gcn
         virtual void mouseExited(MouseEvent& mouseEvent);
         
     protected:
+        /**
+         * Holds the label of the tab.
+         */
         Label* mLabel;
+
+        /**
+         * Holds the tabbed area the tab is a part of.
+         */
         TabbedArea* mTabbedArea;
+
+        /**
+         * Holds the caption of the tab.
+         */
         std::string mCaption;
+
+        /**
+         * True if the tab has the mouse, false otherwise.
+         */
         bool mHasMouse;
     };
 }

--- a/include/guisan/widgets/tabbedarea.hpp
+++ b/include/guisan/widgets/tabbedarea.hpp
@@ -73,8 +73,8 @@ namespace gcn
     class Tab;
     
     /**
-     * With the tabbed area widget several widgets can share the same
-     * space. The widget to view is selected by the user by using tabs.
+     * An implementation of a tabbed area where a user can display a widget by
+     * selecting a tab.
      */
     class GCN_CORE_DECLSPEC TabbedArea:
         public ActionListener,
@@ -97,8 +97,9 @@ namespace gcn
         /**
          * Adds a tab to the tabbed area.
          *
-         * @param caption The caption of the tab.
-         * @param widget The widget to view when the tab is selected.         
+         * @param caption The caption of the tab to add.
+         * @param widget The widget to view when the tab is selected.
+         * @see removeTab, removeTabWithIndex
          */
         virtual void addTab(const std::string& caption, Widget* widget);
 
@@ -106,7 +107,8 @@ namespace gcn
          * Adds a tab to the tabbed area.
          *
          * @param tab The tab widget for the tab.
-         * @param widget The widget to view when the tab is selected.         
+         * @param widget The widget to view when the tab is selected.  
+         * @see removeTab, removeTabWithIndex
          */
         virtual void addTab(Tab* tab, Widget* widget);
 
@@ -114,6 +116,7 @@ namespace gcn
          * Removes a tab from the tabbed area.
          *
          * @param index The index of the tab to remove.
+         * @see addTab
          */
         virtual void removeTabWithIndex(unsigned int index);
         
@@ -121,22 +124,25 @@ namespace gcn
          * Removes a tab from the tabbed area.
          *
          * @param index The tab to remove.
+         * @see addTab
          */
         virtual void removeTab(Tab* tab);
 
         /**
-         * Checks whether a tab given an index is selected.
+         * Checks if a tab given an index is selected or not.
          *
          * @param index The index of the tab to check.
          * @return True if the tab is selected, false otherwise.
+         * @see setSelectedTab
          */
         virtual bool isTabSelected(unsigned int index) const;
         
         /**
-         * Checks whether a tab is selected or not.
+         * Checks if a tab is selected or not.
          *
          * @param index The tab to check.
          * @return True if the tab is selected, false otherwise.
+         * @see setSelectedTab
          */
         virtual bool isTabSelected(Tab* tab);
 
@@ -144,13 +150,15 @@ namespace gcn
          * Sets a tab given an index to be selected.
          *
          * @param index The index of the tab to be selected.
+         * @see isTabSelected, getSelectedTab
          */
-        virtual void setSelectedTabWithIndex(unsigned int index);
+        virtual void setSelectedTab(unsigned int index);
 
         /**
          * Sets a tab to be selected or not.
          *
          * @param index The tab to be selected.
+         * @see isTabSelected, getSelectedTab
          */
         virtual void setSelectedTab(Tab* tab);
 
@@ -159,13 +167,15 @@ namespace gcn
          *
          * @return The undex of the selected tab.
          *         If no tab is selected -1 will be returned.
+         * @see isTabSelected, setSelectedTab
          */
         virtual int getSelectedTabIndex() const;
-        
+
         /**
          * Gets the selected tab.
          *
          * @return The selected tab.
+         * @see isTabSelected, setSelectedTab
          */
         Tab* getSelectedTab();
 
@@ -212,14 +222,39 @@ namespace gcn
          * Adjusts the size of the tabbed area.
          */
         void adjustSize();
+
+        /**
+         * Adjusts the positions ot the tabs.
+         */
         void adjustTabPositions();
-        
+
+        /**
+         * Holds the selected tab.
+         */
         Tab* mSelectedTab;
+
+        /**
+         * Holds the container for the tabs.
+         */
         Container* mTabContainer;
+
+        /**
+         * Holds the container for the widgets.
+         */
         Container* mWidgetContainer;
-        std::vector<Tab*> mTabsToCleanUp;
+
+        /**
+         * Holds a vector of tabs to delete in the destructor.
+         * A tab that is to be deleted is a tab that has been
+         * internally created by the tabbed area.
+         */
+        std::vector<Tab*> mTabsToDelete;
+
+        /**
+         * A map between a tab and a widget to display when the
+         * tab is selected.
+         */
         std::vector<std::pair<Tab*, Widget*> > mTabs;
-        
     };
 }
 

--- a/include/guisan/widgets/textbox.hpp
+++ b/include/guisan/widgets/textbox.hpp
@@ -69,10 +69,7 @@
 namespace gcn
 {
     /**
-     * A TextBox in which you can write and/or display a lines of text.
-     *
-     * NOTE: A plain TextBox is really uggly and looks much better inside a
-     *       ScrollArea.
+     * An implementation of a text box where a user can enter text that contains many lines.
      */
     class GCN_CORE_DECLSPEC TextBox:
         public Widget,
@@ -88,49 +85,56 @@ namespace gcn
         /**
          * Constructor.
          *
-         * @param text the text of the TextBox.
+         * @param text The default text of the text box.
          */
         TextBox(const std::string& text);
 
         /**
-         * Sets the text.
+         * Sets the text of the text box.
          *
-         * @param text the text of the TextBox.
+         * @param text The text of the text box.
+         * @see getText
          */
         void setText(const std::string& text);
 
         /**
-         * Gets the text.
-         * @return the text of the TextBox.
+         * Gets the text of the text box.
+         *
+         * @return The text of the text box.
+         * @see setText
          */
         std::string getText() const;
 
         /**
-         * Gets the row of a text.
+         * Gets a certain row from the text.
          *
-         * @return the text of a certain row in the TextBox.
+         * @param row The number of the row to get from the text.
+         * @return A row from the text of the text box.
+         * @see setTextRow
          */
         const std::string& getTextRow(int row) const;
 
         /**
-         * Sets the text of a certain row in a TextBox.
+         * Sets the text of a certain row of the text.
          *
-         * @param row the row number.
-         * @param text the text of a certain row in the TextBox.
+         * @param row The number of the row to set in the text.
+         * @param text The text to set in the given row number.
+         * @see getTextRow
          */
         void setTextRow(int row, const std::string& text);
 
         /**
          * Gets the number of rows in the text.
          *
-         * @return the number of rows in the text.
+         * @return The number of rows in the text.
          */
         unsigned int getNumberOfRows() const;
 
         /**
          * Gets the caret position in the text.
          *
-         * @return the caret position in the text.
+         * @return The caret position in the text.
+         * @see setCaretPosition
          */
         unsigned int getCaretPosition() const;
 
@@ -138,82 +142,98 @@ namespace gcn
          * Sets the position of the caret in the text.
          *
          * @param position the positon of the caret.
+         * @see getCaretPosition
          */
         void setCaretPosition(unsigned int position);
 
         /**
-         * Gets the row the caret is in in the text.
+         * Gets the row number where the caret is currently located.
          *
-         * @return the row the caret is in in the text.
+         * @return The row number where the caret is currently located.
+         * @see setCaretRow
          */
         unsigned int getCaretRow() const;
 
         /**
-         * Sets the row the caret should be in in the text.
+         * Sets the row where the caret should be currently located.
          *
-         * @param row the row number.
+         * @param The row where the caret should be currently located.
+         * @see getCaretRow
          */
         void setCaretRow(int row);
 
         /**
-         * Gets the column the caret is in in the text.
+         * Gets the column where the caret is currently located.
          *
-         * @return the column the caret is in in the text.
+         * @return The column where the caret is currently located.
+         * @see setCaretColumn
          */
         unsigned int getCaretColumn() const;
 
         /**
-         * Sets the column the caret should be in in the text.
+         * Sets the column where the caret should be currently located.
          *
-         * @param column the column number.
+         * @param The column where the caret should be currently located.
+         * @see getCaretColumn
          */
         void setCaretColumn(int column);
 
         /**
-         * Sets the row and the column the caret should be in in the text.
+         * Sets the row and the column where the caret should be currently
+         * located.
          *
-         * @param row the row number.
-         * @param column the column number.
+         * @param row The row where the caret should be currently located.
+         * @param column The column where the caret should be currently located.
+         * @see getCaretRow, getCaretColumn
          */
         void setCaretRowColumn(int row, int column);
 
         /**
-         * Scrolls the text to the caret if the TextBox is in a ScrollArea.
+         * Scrolls the text to the caret if the text box is in a scroll area.
+         * 
+         * @see ScrollArea
          */
         virtual void scrollToCaret();
 
         /**
-         * Checks if the TextBox is editable.
+         * Checks if the text box is editable.
          *
-         * @return true it the TextBox is editable.
+         * @return True it the text box is editable, false otherwise.
+         * @see setEditable
          */
         bool isEditable() const;
 
         /**
-         * Sets if the TextBox should be editable or not.
+         * Sets the text box to be editable or not.
          *
-         * @param editable true if the TextBox should be editable.
+         * @param editable True if the text box should be editable, false otherwise.
          */
         void setEditable(bool editable);
 
         /**
-         * Adds a text row to the text.
+         * Adds a row of text to the end of the text.
          *
-         * @param row a row.
+         * @param row The row to add.
          */
         virtual void addRow(const std::string row);
 
         /**
-         * Checks if the TextBox is opaque
+         * Checks if the text box is opaque. An opaque text box will draw
+         * its background and its text. A non opaque text box only draw its
+         * text making it transparent.
          *
-         * @return true if the TextBox is opaque
+         * @return True if the text box is opaque, false otherwise.
+         * @see setOpaque
          */
         bool isOpaque();
 
         /**
-         * Sets the TextBox to be opaque.
+         * Sets the text box to be opaque or not. An opaque text box will draw
+         * its background and its text. A non opaque text box only draw its
+         * text making it transparent.
          *
-         * @param opaque true if the TextBox should be opaque.
+         * @param opaque True if the text box should be opaque, false otherwise.
+         * @see isOpaque
          */
         void setOpaque(bool opaque);
 
@@ -240,7 +260,8 @@ namespace gcn
 
     protected:
         /**
-         * Draws the caret.
+         * Draws the caret. Overloaded this method if you want to
+         * change the style of the caret.
          *
          * @param graphics a Graphics object to draw with.
          * @param x the x position.
@@ -249,14 +270,33 @@ namespace gcn
         virtual void drawCaret(Graphics* graphics, int x, int y);
 
         /**
-         * Adjusts the TextBox size to fit the font size.
+         * Adjusts the text box's size to fit the text.
          */
         virtual void adjustSize();
 
+        /**
+         * Holds all the rows of the text.
+         */
         std::vector<std::string> mTextRows;
+
+        /**
+         * Holds the current column of the caret.
+         */
         int mCaretColumn;
+
+        /**
+         * Holds the current row of the caret.
+         */
         int mCaretRow;
+
+        /**
+         * True if the text box is editable, false otherwise.
+         */
         bool mEditable;
+
+        /**
+         * True if the text box is editable, false otherwise.
+         */
         bool mOpaque;
     };
 }

--- a/include/guisan/widgets/textfield.hpp
+++ b/include/guisan/widgets/textfield.hpp
@@ -67,7 +67,7 @@
 namespace gcn
 {
     /**
-     * A text field in which you can write or display a line of text.
+     * An implementation of a text field where a user can enter a line of text.
      */
     class GCN_CORE_DECLSPEC TextField:
         public Widget,
@@ -76,66 +76,59 @@ namespace gcn
     {
     public:
         /**
-         * Default constructor.
+         * Constructor.
          */
         TextField();
 
         /**
-         * Constructor. Initializes the textfield with a given string.
+         * Constructor. The text field will be automatically resized
+         * to fit the text.
          *
-         * @param text the initial text.
+         * @param text The default text of the text field.
          */
         TextField(const std::string& text);
 
         /**
-         * Sets the text.
+         * Sets the text of the text field.
          *
-         * @param text the new text in the TextField.
+         * @param text The text of the text field.
+         * @see getText
          */
         void setText(const std::string& text);
 
         /**
-         * Gets the text.
+         * Gets the text of the text field.
          *
-         * @return the text of the TextField.
+         * @return The text of the text field.
+         * @see setText
          */
         const std::string& getText() const;
 
         /**
-         * Draws the caret (the little marker in the text that shows where the
-         * letters you type will appear). Easily overloaded if you want to
-         * change the style of the caret.
-         *
-         * @param graphics the Graphics object to draw with.
-         * @param x the caret's x-position.
-         */
-        virtual void drawCaret(Graphics* graphics, int x);
-
-        /**
-         * Adjusts the size of the TextField to fit the font size. The
-         * constructor taking a string uses this function to initialize the
-         * size of the TextField.
+         * Adjusts the size of the text field to fit the text.
          */
         void adjustSize();
 
         /**
-         * Adjusts the height of the text field to fit the font size. The
-         * height of the TextField is initialized with this function by the
-         * constructors.
+         * Adjusts the height of the text field to fit caption.
          */
         void adjustHeight();
 
         /**
-         * Sets the caret position.
+         * Sets the caret position. As there is only one line of text
+         * in a text field the position is the caret's x coordinate.
          *
-         * @param position the caret position.
+         * @param position The caret position.
+         * @see getCaretPosition
          */
         void setCaretPosition(unsigned int position);
 
         /**
-         * Gets the caret position.
+         * Gets the caret position. As there is only one line of text
+         * in a text field the position is the caret's x coordinate.
          *
-         * @return the caret position.
+         * @return The caret position.
+         * @see setCaretPosition
          */
         unsigned int getCaretPosition() const;
 
@@ -162,12 +155,36 @@ namespace gcn
 
     protected:
         /**
+         * Draws the caret. Overloaded this method if you want to
+         * change the style of the caret.
+         *
+         * @param graphics the Graphics object to draw with.
+         * @param x the caret's x-position.
+         */
+        virtual void drawCaret(Graphics* graphics, int x);
+
+        /**
          * Scrolls the text horizontally so that the caret shows if needed.
+         * The method is used any time a user types in the text field so the
+         * caret always will be shown.
          */
         void fixScroll();
 
+        /**
+         * Holds the text of the text box.
+         */
         std::string mText;
+
+        /**
+         * Holds the caret position.
+         */
         unsigned int mCaretPosition;
+
+        /**
+         * Holds the amount scrolled in x. If a user types more characters than
+         * the text field can display, due to the text field being to small, the
+         * text needs to scroll in order to show the last type character.
+         */
         int mXScroll;
     };
 }

--- a/include/guisan/widgets/window.hpp
+++ b/include/guisan/widgets/window.hpp
@@ -66,7 +66,7 @@
 namespace gcn
 {
     /**
-     * A movable window which can contain another Widgets.
+     * An implementation of a movable window that can contain other widgets.
      */
     class GCN_CORE_DECLSPEC Window : public Container,
                                      public MouseListener
@@ -78,9 +78,10 @@ namespace gcn
         Window();
 
         /**
-         * Constructor.
+         * Constructor. The window will be automatically resized in height
+         * to fit the caption.
          *
-         * @param caption the Window caption.
+         * @param caption the caption of the window.
          */
         Window(const std::string& caption);
 
@@ -90,93 +91,106 @@ namespace gcn
         virtual ~Window();
 
         /**
-         * Sets the Window caption.
+         * Sets the caption of the window.
          *
-         * @param caption the Window caption.
+         * @param caption The caption of the window.
+         * @see getCaption
          */
         void setCaption(const std::string& caption);
 
         /**
-         * Gets the Window caption.
+         * Gets the caption of the window.
          *
-         * @return the Window caption.
+         * @return the caption of the window.
+         * @see setCaption
          */
         const std::string& getCaption() const;
 
         /**
-         * Sets the alignment for the caption.
+         * Sets the alignment of the caption.
          *
-         * @param alignment Graphics::LEFT, Graphics::CENTER or Graphics::RIGHT.
+         * @param alignment The alignment of the caption.
+         * @see getAlignment, Graphics
          */
-        void setAlignment(unsigned int alignment);
+        void setAlignment(Graphics::Alignment alignment);
 
         /**
-         * Gets the alignment for the caption.
+         * Gets the alignment of the caption.
          *
-         * @return alignment of caption.
+         * @return The alignment of caption.
+         * @see setAlignment, Graphics
          */
-        unsigned int getAlignment() const;
+        Graphics::Alignment getAlignment() const;
 
         /**
-         * Sets the padding of the window which is the distance between the
+         * Sets the padding of the window. The padding is the distance between the
          * window border and the content.
          *
-         * @param padding the padding value.
+         * @param padding The padding of the window.
+         * @see getPadding
          */
         void setPadding(unsigned int padding);
 
         /**
-         * Gets the padding.
+         * Gets the padding of the window. The padding is the distance between the
+         * window border and the content.
          *
-         * @return the padding value.
+         * @return The padding of the window.
+         * @see setPadding
          */
         unsigned int getPadding() const;
 
         /**
          * Sets the title bar height.
          *
-         * @param height the title height value.
+         * @param height The title height value.
+         * @see getTitleBarHeight
          */
         void setTitleBarHeight(unsigned int height);
 
         /**
          * Gets the title bar height.
          *
-         * @return the title bar height.
+         * @return The title bar height.
+         * @see setTitleBarHeight
          */
         unsigned int getTitleBarHeight();
 
         /**
-         * Sets the Window to be moveble.
+         * Sets the window to be moveble or not.
          *
-         * @param movable true or false.
+         * @param movable True if the window should be movable, false otherwise.
+         * @see isMovable
          */
         void setMovable(bool movable);
 
         /**
-         * Check if the window is movable.
+         * Checks if the window is movable.
          *
-         * @return true or false.
+         * @return True if the window is movable, false otherwise.
+         * @see setMovable
          */
         bool isMovable() const;
 
         /**
-         * Sets the Window to be opaque. If it's not opaque, the content area
-         * will not be filled with a color.
+         * Sets the window to be opaque or not. An opaque window will draw its background
+         * and its content. A non opaque window will only draw its content.
          *
-         * @param opaque true or false.
+         * @param opaque True if the window should be opaque, false otherwise.
+         * @see isOpaque
          */
         void setOpaque(bool opaque);
 
         /**
-         * Checks if the Window is opaque.
+         * Checks if the window is opaque.
          *
-         * @return true or false.
+         * @return True if the window is opaque, false otherwise.
+         * @see setOpaque
          */
         bool isOpaque();
 
         /**
-         * Resizes the container to fit the content exactly.
+         * Resizes the window to fit the content.
          */
         virtual void resizeToContent();
 
@@ -202,15 +216,54 @@ namespace gcn
         virtual void mouseReleased(MouseEvent& mouseEvent);
 
     protected:
+        /**
+         * Holds the caption of the window.
+         */
         std::string mCaption;
-        unsigned int mAlignment;
+
+        /**
+         * Holds the alignment of the caption.
+         */
+        Graphics::Alignment mAlignment;
+
+        /**
+         * Holds the padding of the window.
+         */
         unsigned int mPadding;
+
+        /**
+         * Holds the title bar height of the window.
+         */
         unsigned int mTitleBarHeight;
+
+        /**
+         * True if the window is movable, false otherwise.
+         */
         bool mMovable;
+
+        /**
+         * True if the window is opaque, false otherwise.
+         */
         bool mOpaque;
+
+        /**
+         * Holds a drag offset as an x coordinate where the drag of the window
+         * started if the window is being dragged. It's used to move the window 
+         * correctly when dragged.
+         */
         int mDragOffsetX;
+
+        /**
+         * Holds a drag offset as an y coordinate where the drag of the window
+         * started if the window is being dragged. It's used to move the window 
+         * correctly when dragged.
+         */
         int mDragOffsetY;
-        bool mIsMoving;
+
+        /**
+         * True if the window is being moved, false otherwise.
+         */
+        bool mMoved;
     };
 }
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -153,7 +153,7 @@ namespace gcn
     }
 
     void Graphics::drawText(const std::string& text, int x, int y,
-                            unsigned int alignment)
+                            Alignment alignment)
     {
         if (mFont == NULL)
         {

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -112,12 +112,12 @@ namespace gcn
         return mCaption;
     }
 
-    void Button::setAlignment(unsigned int alignment)
+    void Button::setAlignment(Graphics::Alignment alignment)
     {
         mAlignment = alignment;
     }
 
-    unsigned int Button::getAlignment() const
+    Graphics::Alignment Button::getAlignment() const
     {
         return mAlignment;
     }

--- a/src/widgets/inputbox.cpp
+++ b/src/widgets/inputbox.cpp
@@ -270,8 +270,8 @@ namespace gcn
 
         mDragOffsetX = mouseEvent.getX();
         mDragOffsetY = mouseEvent.getY();
-        
-        mIsMoving = mouseEvent.getY() <= (int)mTitleBarHeight;
+
+        mMoved = mouseEvent.getY() <= (int)mTitleBarHeight;
     }
 
     void InputBox::mouseReleased(MouseEvent& mouseEvent)
@@ -293,7 +293,7 @@ namespace gcn
         }
         else
         {
-            mIsMoving = false;
+            mMoved = false;
         }
     }
 
@@ -304,7 +304,7 @@ namespace gcn
             return;
         }
         
-        if (isMovable() && mIsMoving)
+        if (isMovable() && mMoved)
         {
             setPosition(mouseEvent.getX() - mDragOffsetX + getX(),
                         mouseEvent.getY() - mDragOffsetY + getY());

--- a/src/widgets/label.cpp
+++ b/src/widgets/label.cpp
@@ -90,12 +90,12 @@ namespace gcn
         mCaption = caption;
     }
 
-    void Label::setAlignment(unsigned int alignment)
+    void Label::setAlignment(Graphics::Alignment alignment)
     {
         mAlignment = alignment;
     }
 
-    unsigned int Label::getAlignment() const
+    Graphics::Alignment Label::getAlignment() const
     {
         return mAlignment;
     }

--- a/src/widgets/messagebox.cpp
+++ b/src/widgets/messagebox.cpp
@@ -209,17 +209,7 @@ namespace gcn
         return mCaption;
     }
 
-    void MessageBox::setAlignment(unsigned int alignment)
-    {
-        mAlignment = alignment;
-    }
-
-    unsigned int MessageBox::getAlignment() const
-    {
-        return mAlignment;
-    }
-    
-    void MessageBox::setButtonAlignment(unsigned int alignment)
+    void MessageBox::setButtonAlignment(Graphics::Alignment alignment)
     {
         mButtonAlignment = alignment;
         
@@ -246,8 +236,8 @@ namespace gcn
             }
         }
     }
-    
-    unsigned int MessageBox::getButtonAlignment() const
+
+    Graphics::Alignment MessageBox::getButtonAlignment() const
     {
         return mButtonAlignment;
     }
@@ -387,8 +377,8 @@ namespace gcn
 
         mDragOffsetX = mouseEvent.getX();
         mDragOffsetY = mouseEvent.getY();
-        
-        mIsMoving = mouseEvent.getY() <= (int)mTitleBarHeight;
+
+        mMoved = mouseEvent.getY() <= (int)mTitleBarHeight;
     }
 
     void MessageBox::mouseReleased(MouseEvent& mouseEvent)
@@ -407,7 +397,7 @@ namespace gcn
         }
         else
         {
-            mIsMoving = false;
+            mMoved = false;
         }
     }
 
@@ -418,7 +408,7 @@ namespace gcn
             return;
         }
         
-        if (isMovable() && mIsMoving)
+        if (isMovable() && mMoved)
         {
             setPosition(mouseEvent.getX() - mDragOffsetX + getX(),
                         mouseEvent.getY() - mDragOffsetY + getY());

--- a/src/widgets/progressbar.cpp
+++ b/src/widgets/progressbar.cpp
@@ -125,12 +125,12 @@ namespace gcn
         mCaption = caption;
     }
 
-    void ProgressBar::setAlignment(unsigned int alignment)
+    void ProgressBar::setAlignment(Graphics::Alignment alignment)
     {
         mAlignment = alignment;
     }
 
-    unsigned int ProgressBar::getAlignment() const
+    Graphics::Alignment ProgressBar::getAlignment() const
     {
         return mAlignment;
     }

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -108,7 +108,7 @@ namespace gcn
         addMouseListener(this);
     }
 
-    ScrollArea::ScrollArea(Widget *content, unsigned int hPolicy, unsigned int vPolicy)
+    ScrollArea::ScrollArea(Widget *content, ScrollPolicy hPolicy, ScrollPolicy vPolicy)
     {
         mVScroll = 0;
         mHScroll = 0;
@@ -161,29 +161,29 @@ namespace gcn
         return NULL;
     }
 
-    void ScrollArea::setHorizontalScrollPolicy(unsigned int hPolicy)
+    void ScrollArea::setHorizontalScrollPolicy(ScrollPolicy hPolicy)
     {
         mHPolicy = hPolicy;
         checkPolicies();
     }
 
-    unsigned int ScrollArea::getHorizontalScrollPolicy() const
+    ScrollArea::ScrollPolicy ScrollArea::getHorizontalScrollPolicy() const
     {
         return mHPolicy;
     }
 
-    void ScrollArea::setVerticalScrollPolicy(unsigned int vPolicy)
+    void ScrollArea::setVerticalScrollPolicy(ScrollPolicy vPolicy)
     {
         mVPolicy = vPolicy;
         checkPolicies();
     }
 
-    unsigned int ScrollArea::getVerticalScrollPolicy() const
+    ScrollArea::ScrollPolicy ScrollArea::getVerticalScrollPolicy() const
     {
         return mVPolicy;
     }
 
-    void ScrollArea::setScrollPolicy(unsigned int hPolicy, unsigned int vPolicy)
+    void ScrollArea::setScrollPolicy(ScrollPolicy hPolicy, ScrollPolicy vPolicy)
     {
         mHPolicy = hPolicy;
         mVPolicy = vPolicy;

--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -68,8 +68,7 @@ namespace gcn
 {
     Slider::Slider(double scaleEnd)
     {
-        mMouseDrag = false;
-
+        mDragged = false;
 
         mScaleStart = 0;
         mScaleEnd = scaleEnd;
@@ -87,7 +86,7 @@ namespace gcn
 
     Slider::Slider(double scaleStart, double scaleEnd)
     {
-        mMouseDrag = false;
+        mDragged = false;
 
         mScaleStart = scaleStart;
         mScaleEnd = scaleEnd;
@@ -332,12 +331,12 @@ namespace gcn
         }
     }
 
-    void Slider::setOrientation(unsigned int orientation)
+    void Slider::setOrientation(Orientation orientation)
     {
         mOrientation = orientation;
     }
 
-    unsigned int Slider::getOrientation() const
+    Slider::Orientation Slider::getOrientation() const
     {
         return mOrientation;
     }

--- a/src/widgets/tabbedarea.cpp
+++ b/src/widgets/tabbedarea.cpp
@@ -97,9 +97,9 @@ namespace gcn
         delete mWidgetContainer;
 
         unsigned int i;
-        for (i = 0; i < mTabsToCleanUp.size(); i++)
+        for (i = 0; i < mTabsToDelete.size(); i++)
         {
-            delete mTabsToCleanUp[i];
+            delete mTabsToDelete[i];
         }
     }
 
@@ -108,8 +108,8 @@ namespace gcn
         Tab* tab = new Tab();
         tab->setSize(70, 20);
         tab->setCaption(caption);
-        mTabsToCleanUp.push_back(tab);
-        
+        mTabsToDelete.push_back(tab);
+
         addTab(tab, widget);
     }
 
@@ -177,11 +177,11 @@ namespace gcn
         }
                 
         std::vector<Tab*>::iterator iter2;
-        for (iter2 = mTabsToCleanUp.begin(); iter2 != mTabsToCleanUp.end(); iter2++)
+        for (iter2 = mTabsToDelete.begin(); iter2 != mTabsToDelete.end(); iter2++)
         {
             if (*iter2 == tab)
             {
-                mTabsToCleanUp.erase(iter2);
+                mTabsToDelete.erase(iter2);
                 delete tab;
                 break;
             }
@@ -194,7 +194,7 @@ namespace gcn
         }
         else
         {
-            setSelectedTabWithIndex(tabIndexToBeSelected);
+            setSelectedTab(tabIndexToBeSelected);
         }
         
         adjustSize();
@@ -216,7 +216,7 @@ namespace gcn
         return mSelectedTab == tab;
     }
 
-    void TabbedArea::setSelectedTabWithIndex(unsigned int index)
+    void TabbedArea::setSelectedTab(unsigned int index)
     {
         if (index >= mTabs.size())
         {

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -68,7 +68,7 @@
 namespace gcn
 {
     Window::Window()
-        :mIsMoving(false)
+        :mMoved(false)
     {
         setBorderSize(1);
         setPadding(2);
@@ -80,7 +80,7 @@ namespace gcn
     }
 
     Window::Window(const std::string& caption)
-        :mIsMoving(false)
+        :mMoved(false)
     {
         setCaption(caption);
         setBorderSize(1);
@@ -126,12 +126,12 @@ namespace gcn
         return mCaption;
     }
 
-    void Window::setAlignment(unsigned int alignment)
+    void Window::setAlignment(Graphics::Alignment alignment)
     {
         mAlignment = alignment;
     }
 
-    unsigned int Window::getAlignment() const
+    Graphics::Alignment Window::getAlignment() const
     {
         return mAlignment;
     }
@@ -272,12 +272,12 @@ namespace gcn
         mDragOffsetX = mouseEvent.getX();
         mDragOffsetY = mouseEvent.getY();
 
-        mIsMoving = mouseEvent.getY() <= (int)mTitleBarHeight;
+        mMoved = mouseEvent.getY() <= (int)mTitleBarHeight;
     }
 
     void Window::mouseReleased(MouseEvent& mouseEvent)
     {
-        mIsMoving = false;
+        mMoved = false;
     }
 
     void Window::mouseDragged(MouseEvent& mouseEvent)
@@ -287,7 +287,7 @@ namespace gcn
             return;
         }
 
-        if (isMovable() && mIsMoving)
+        if (isMovable() && mMoved)
         {
             setPosition(mouseEvent.getX() - mDragOffsetX + getX(),
                 mouseEvent.getY() - mDragOffsetY + getY());


### PR DESCRIPTION
- Documentation has been enhanced.
- The alignment `enum` in `Graphics`, the orientation `enum` in `Slider` and the scroll policy `enum` in `ScrollArea` are no longer anonymous enums.
- Locale variable names have in some places been changed to better reflect their purpose.
- move some methods from `public` to `protected`.