### PR TITLE
Fix `Key::isPrintable()`

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -89,7 +89,7 @@ namespace gcn
 
     bool Key::isPrintable() const
     {
-        return 0 < mValue && mValue < 1000;
+        return 32 <= mValue && mValue < 1000;
     }
 
     int Key::getValue() const


### PR DESCRIPTION
Especially enter/tabulation are not printable: #23 breaks tab and enter (without Ctrl/Alt) handling.