### PR TITLE
Apply Guichan's changes from e5271f1ad79923ffa1810e2bc62435117d49ce9f…

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Continue rebasing from 2bc3319195c94fd4ba3d87e0a9f095bca211646e
+* Continue rebasing from 29eb696aaf7aa7a78cece7d25f27d0235e4559ed
 * Add a focus listener interface.
 * Make focus apply synchronously.
 * Graphics and input objects for DirectX.

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -518,7 +518,14 @@ namespace gcn
 
         int sourceWidgetX, sourceWidgetY;
         sourceWidget->getAbsolutePosition(sourceWidgetX, sourceWidgetY);
-        
+
+        if (mFocusHandler->getModalFocused() != NULL
+            && sourceWidget->isModalFocused()
+            || mFocusHandler->getModalFocused() == NULL)
+        {
+            sourceWidget->requestFocus();
+        }
+
         distributeMouseEvent(sourceWidget,
                              MouseEvent::PRESSED,
                              mouseInput.getButton(),
@@ -526,13 +533,6 @@ namespace gcn
                              mouseInput.getY());
 
         mFocusHandler->setLastWidgetPressed(sourceWidget);
-        
-        if (mFocusHandler->getModalFocused() != NULL
-            && sourceWidget->isModalFocused()
-            || mFocusHandler->getModalFocused() == NULL)
-        {
-            sourceWidget->requestFocus();
-        }
 
         mFocusHandler->setDraggedWidget(sourceWidget);
         mLastMouseDragButton = mouseInput.getButton();


### PR DESCRIPTION
… (Feb 8th 2008)

Focus is now requested by a pressed widget before the widget distribute its events making it possible to remove a widget from the Gui in one of the event handlers without raising an exception. See http://code.google.com/p/guichan/issues/detail?id=24