### PR TITLE
Apply Guichan's changes from c53768e2b5994d460ce6478103b6fdbe57b5aecb…

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Continue rebasing from a154429864dc2a948d29f21cdcdf688177bb54a8
+* Continue rebasing from faa1ff7131c82dde9d83c779b9e7ba2dc9170310
 * Add a focus listener interface.
 * Make focus apply synchronously.
 * Graphics and input objects for DirectX.

--- a/include/guisan/exception.hpp
+++ b/include/guisan/exception.hpp
@@ -61,12 +61,9 @@
 
 #include "guisan/platform.hpp"
 
-
-#ifdef _MSC_VER
-#if _MSC_VER <= 1200
-#define __FUNCTION__ "?"
-#endif
-#endif
+# ifndef __FUNCTION__
+#  define __FUNCTION__ "?"
+# endif
 
 /*
  * A macro used to create a standard exception object.
@@ -84,9 +81,9 @@ namespace gcn
 
     /**
      * An exception containing a message, a file and a line number
-     * where the exception occured. Guisan will only throw exceptions 
-     * of this class. 
-     * 
+     * where the exception occured. Guisan will only throw exceptions
+     * of this class.
+     *
      * You can use this class for your own exceptions that has
      * something to do with a GUI exception. A nifty feature of the
      * excpetion class is that it can tell you from which line and


### PR DESCRIPTION
… (May 10th 2008)

Borland compile issue has been fixed. The __FUNCTION__ define is apparently not available with Borland compilers.