### PR TITLE
Apply Guichan's changes from f0e7bcb9b32c2fddfcc8c76c16cbd06e136caa07…

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Continue rebasing from f0e7bcb9b32c2fddfcc8c76c16cbd06e136caa07
+* Continue rebasing from 6725f3b08248d94e3ac11ce530aec42e3029fc62
 * Add a focus listener interface.
 * Make focus apply synchronously.
 * Graphics and input objects for DirectX.

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -528,6 +528,16 @@ namespace gcn
             sourceWidget->requestFocus();
         }
 
+        if (mouseInput.getTimeStamp() - mLastMousePressTimeStamp < 250
+            && mLastMousePressButton == mouseInput.getButton())
+        {
+            mClickCount++;
+        }
+        else
+        {
+            mClickCount = 1;
+        }
+
         distributeMouseEvent(sourceWidget,
                              MouseEvent::Pressed,
                              mouseInput.getButton(),
@@ -538,16 +548,6 @@ namespace gcn
 
         mFocusHandler->setDraggedWidget(sourceWidget);
         mLastMouseDragButton = mouseInput.getButton();
-
-        if (mLastMousePressTimeStamp < 300
-            && mLastMousePressButton == mouseInput.getButton())
-        {
-            mClickCount++;
-        }
-        else
-        {
-            mClickCount = 1;
-        }
 
         mLastMousePressButton = mouseInput.getButton();
         mLastMousePressTimeStamp = mouseInput.getTimeStamp();


### PR DESCRIPTION
… (Sept 10th 2008)

Click count in mouse events should now work as expected if the time stamp supplied by back ends is a time stamp in milliseconds when the event occurred.