### PR TITLE
Apply Guichan's changes from 6725f3b08248d94e3ac11ce530aec42e3029fc62…

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Continue rebasing from 6725f3b08248d94e3ac11ce530aec42e3029fc62
+* Continue rebasing from 840e2ea3b13eb24057b8505eaa615d4e6bd363c6
 * Add a focus listener interface.
 * Make focus apply synchronously.
 * Graphics and input objects for DirectX.

--- a/src/widgets/listbox.cpp
+++ b/src/widgets/listbox.cpp
@@ -169,20 +169,6 @@ namespace gcn
     void ListBox::logic()
     {
         adjustSize();
-
-        Rectangle scroll;
-
-        if (mSelected < 0)
-        {
-            scroll.y = 0;
-        }
-        else
-        {
-            scroll.y = getRowHeight() * mSelected;
-        }
-
-        scroll.height = getRowHeight();
-        showPart(scroll);
     }
 
     int ListBox::getSelected() const
@@ -211,6 +197,19 @@ namespace gcn
                 mSelected = selected;
             }
         }
+        Rectangle scroll;
+
+        if (mSelected < 0)
+        {
+            scroll.y = 0;
+        }
+        else
+        {
+            scroll.y = getRowHeight() * mSelected;
+        }
+
+        scroll.height = getRowHeight();
+        showPart(scroll);
 
         distributeValueChangedEvent();
     }


### PR DESCRIPTION
… (Sept 14th 2008)

A bug prevented scroll area from scrolling a list box correctly. It was caused by the fact that list box called Widget::showPart on every logic call to fix it's scroll when a user goes up and down the list which caused the scroll areas scroll to be ignored. The problem has been fixed by only calling Widget::showPart when a new item in the list box has been selected.