### PR TITLE
Fix `Text` default constructor.

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -53,7 +53,9 @@
 namespace gcn
 {
     Text::Text() : mCaretPosition(0), mCaretColumn(0), mCaretRow(0)
-    {}
+    {
+        mRows.emplace_back();
+    }
 
     Text::Text(const std::string& content) : mCaretPosition(0), mCaretColumn(0), mCaretRow(0)
     {


### PR DESCRIPTION
@midwan: It fixes default constructor of `Text` (not fixed in Guichan :-/ )
I hope it is sufficient.