### PR TITLE
fixed window widget drawText (missing isEnabled)

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -227,7 +227,7 @@ namespace gcn
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
         graphics->pushClipArea(Rectangle(0, 0, getWidth(), getTitleBarHeight() - 1));
-        graphics->drawText(getCaption(), textX, textY, getAlignment());
+        graphics->drawText(getCaption(), textX, textY, getAlignment(), isEnabled());
         graphics->popClipArea();
     }
 


### PR DESCRIPTION
The window widget was missed during the widget updates in #75 - the drawText function call should have had an `isEnabled()` parameter.