### PR TITLE
Improve listbox adjustsize

### DIFF
--- a/src/widgets/listbox.cpp
+++ b/src/widgets/listbox.cpp
@@ -319,6 +319,17 @@ namespace gcn
     {
         if (mListModel != NULL)
         {
+            int maxElementLength = getWidth();
+            for (int i = 0; i < mListModel->getNumberOfElements(); i++)
+            {
+                const auto elementLength =  getFont()->getWidth(mListModel->getElementAt(i));
+                if (elementLength > maxElementLength)
+                {
+                    maxElementLength = elementLength;
+                }
+            }
+            if (maxElementLength > getWidth())
+                setWidth(maxElementLength + 4);
             setHeight(getRowHeight() * mListModel->getNumberOfElements());
         }
     }


### PR DESCRIPTION
Listboxes' adjustSize would only do so vertically. This improves it to also adjust the horizontal size. Useful when using file/directory requesters, and you have very long filenames somewhere (if it doesn't resize, you cannot scroll to see the content)