### PR TITLE
Remove wrong forward declaration `class Widget;` (which is different …

### DIFF
--- a/include/guisan.hpp
+++ b/include/guisan.hpp
@@ -115,8 +115,6 @@
 
 #include "guisan/platform.hpp"
 
-class Widget;
-
 extern "C"
 {
     /**


### PR DESCRIPTION
…than `gcn::Widget`).