### PR TITLE
Make `Widget` as primary base:

### DIFF
--- a/include/guisan/widgets/dropdown.hpp
+++ b/include/guisan/widgets/dropdown.hpp
@@ -89,12 +89,12 @@ namespace gcn
      * will be sent to all action listeners of the drop down.
      */
     class GCN_CORE_DECLSPEC DropDown :
+        public Widget,
         public ActionListener,
         public KeyListener,
         public MouseListener,
         public FocusListener,
-        public SelectionListener,
-        public Widget
+        public SelectionListener
     {
     public:
         /**

--- a/include/guisan/widgets/scrollarea.hpp
+++ b/include/guisan/widgets/scrollarea.hpp
@@ -73,8 +73,8 @@ namespace gcn
      *       ScrollArea.
      */
     class GCN_CORE_DECLSPEC ScrollArea:
-        public MouseListener,
-        public Widget
+        public Widget,
+        public MouseListener
     {
     public:
         /**

--- a/include/guisan/widgets/tab.hpp
+++ b/include/guisan/widgets/tab.hpp
@@ -75,9 +75,9 @@ namespace gcn
      * @see TabbedArea
      * @since 0.8.0
      */
-    class GCN_CORE_DECLSPEC Tab:
-        public MouseListener,
-        public Widget
+    class GCN_CORE_DECLSPEC Tab :
+        public Widget,
+        public MouseListener
     {
     public:
 

--- a/include/guisan/widgets/tabbedarea.hpp
+++ b/include/guisan/widgets/tabbedarea.hpp
@@ -78,11 +78,11 @@ namespace gcn
      *
      * @since 0.8.0
      */
-    class GCN_CORE_DECLSPEC TabbedArea:
+    class GCN_CORE_DECLSPEC TabbedArea :
+        public Widget,
         public ActionListener,
         public KeyListener,
-        public MouseListener,
-        public Widget
+        public MouseListener
     {
         friend class Tab;
 


### PR DESCRIPTION
Allow to have Widget base and widget pointer inter-convertible. Needed for some binder (as tolua++) which might store pointer as `void*` and cast back to base for virtual call).

This one is needed for Stratagus, a project which actually uses a patched Guichan.