### PR TITLE
Use smart pointers

### DIFF
--- a/demo/ff/include/ffdemo.hpp
+++ b/demo/ff/include/ffdemo.hpp
@@ -103,9 +103,6 @@ private:
     std::unique_ptr<gcn::Icon> mPerIcon;
     std::unique_ptr<gcn::Icon> mOlofIcon;
     std::unique_ptr<gcn::Icon> mTomasIcon;
-    std::unique_ptr<gcn::Image> mPerImage;
-    std::unique_ptr<gcn::Image> mOlofImage;
-    std::unique_ptr<gcn::Image> mTomasImage;
     std::unique_ptr<gcn::Image> mSplashImage;
     std::unique_ptr<gcn::Font> mFontWhite;
     std::unique_ptr<gcn::Font> mFontCyan;

--- a/demo/ff/src/ffdemo.cpp
+++ b/demo/ff/src/ffdemo.cpp
@@ -166,13 +166,9 @@ void FFDemo::initMain()
     mMain->setDimension(gcn::Rectangle(0, 0, 320, 240));
     mTop->add(mMain.get());
 
-    mPerImage.reset(gcn::Image::load("images/finalman.png"));
-    mOlofImage.reset(gcn::Image::load("images/yakslem.png"));
-    mTomasImage.reset(gcn::Image::load("images/peak.png"));
-
-    mPerIcon = std::make_unique<gcn::Icon>(mPerImage.get());
-    mOlofIcon = std::make_unique<gcn::Icon>(mOlofImage.get());
-    mTomasIcon = std::make_unique<gcn::Icon>(mTomasImage.get());
+    mPerIcon = std::make_unique<gcn::Icon>("images/finalman.png");
+    mOlofIcon = std::make_unique<gcn::Icon>("images/yakslem.png");
+    mTomasIcon = std::make_unique<gcn::Icon>("images/peak.png");
 
     mPerInfo1 = std::make_unique<gcn::TextBox>("\n  LV\n  HP\n  MP");
     mPerInfo1->setFont(mFontCyan.get());

--- a/examples/widgets_example.hpp
+++ b/examples/widgets_example.hpp
@@ -41,18 +41,19 @@ namespace WidgetsExample
             // The global font is static and must be set.
             gcn::Widget::setGlobalFont(font.get());
 
-            top = std::make_unique < gcn::Container>();
+            top = std::make_unique<gcn::Container>();
             // Set the dimension of the top container to match the screen.
             top->setDimension(gcn::Rectangle(0, 0, width, height));
             // Set the top container
             gui.setTop(top.get());
+
+            guisanLogoImage.reset(gcn::Image::load("guisan-logo.png"));
             /*
              * Create all the widgets
              */
             label = std::make_unique<gcn::Label>("Label");
 
-            image.reset(gcn::Image::load("guisan.png"));
-            icon = std::make_unique<gcn::Icon>(image.get());
+            icon = std::make_unique<gcn::Icon>("guisan.png");
 
             button = std::make_unique<gcn::Button>("Button");
 
@@ -125,8 +126,7 @@ namespace WidgetsExample
             messageBox->setFrameSize(1);
             messageBox->addActionListener(this);
 
-            guisanLogoImage.reset(gcn::Image::load("guisan-logo.png"));
-            guisanLogoIcon = std::make_unique<gcn::Icon>(guisanLogoImage.get());
+            guisanLogoIcon = std::make_unique<gcn::Icon>(guisanLogoImage);
             window->add(guisanLogoIcon.get());
             window->resizeToContent();
 
@@ -239,11 +239,10 @@ namespace WidgetsExample
         std::unique_ptr<gcn::RadioButton> radioButton3;
         std::unique_ptr<gcn::ToggleButton> toggleButton;
         std::unique_ptr<gcn::Slider> slider; // A slider
-        std::unique_ptr<gcn::Image> image; // An image for the icon
         std::unique_ptr<gcn::Window> window;
         std::unique_ptr<gcn::MessageBox> messageBox;
         std::unique_ptr<gcn::ProgressBar> progress;
-        std::unique_ptr<gcn::Image> guisanLogoImage;
+        std::shared_ptr<gcn::Image> guisanLogoImage;
         std::unique_ptr<gcn::Icon> guisanLogoIcon;
         std::unique_ptr<gcn::ScrollArea> nestedScrollArea;
         std::unique_ptr<gcn::Container> nestedContainer;

--- a/include/guisan/imagefont.hpp
+++ b/include/guisan/imagefont.hpp
@@ -63,6 +63,8 @@
 #include "guisan/platform.hpp"
 #include "guisan/rectangle.hpp"
 
+#include <memory>
+
 namespace gcn
 {
     class Color;
@@ -119,7 +121,19 @@ pqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"); @endcode
          * @throws Exception when glyph list is incorrect or the font image is
          *                   is missing.
          */
-        ImageFont(Image* image, const std::string& glyphs);
+        [[deprecated]] ImageFont(Image* image, const std::string& glyphs);
+
+        /**
+         * Constructor. Takes an image containing the font and
+         * a string containing the glyphs. The glyphs in the string should
+         * be in the same order as they appear in the font image.
+         *
+         * @param image The image with font glyphs.
+         * @param glyphs The glyphs found in the image.
+         * @throws Exception when glyph list is incorrect or the font image is
+         *                   is missing.
+         */
+        ImageFont(std::shared_ptr<Image> image, const std::string& glyphs);
 
         /**
          * Constructor. Takes an image file containing the font and
@@ -142,7 +156,7 @@ pqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"); @endcode
         /**
          * Destructor.
          */
-        ~ImageFont() override;
+        ~ImageFont() override = default;
 
         /**
          * Draws a glyph.
@@ -228,6 +242,12 @@ pqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"); @endcode
          */
         Rectangle scanForGlyph(unsigned char glyph, int x, int y, const Color& separator) const;
 
+    protected:
+        /**
+         * Holds the image with the font data.
+         */
+        std::shared_ptr<Image> mImage;
+
         /**
          * Holds the glyphs areas in the image.
          */
@@ -247,16 +267,6 @@ pqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"); @endcode
          * Holds the row spacing of the image font.
          */
         int mRowSpacing = 0;
-
-        /**
-         * Holds the image with the font data.
-         */
-        Image* mImage = nullptr;
-
-        /**
-         * Holds the filename of the image with the font data.
-         */
-        std::string mFilename;
     };
 }
 

--- a/include/guisan/widgets/dropdown.hpp
+++ b/include/guisan/widgets/dropdown.hpp
@@ -66,6 +66,8 @@
 #include "guisan/selectionlistener.hpp"
 #include "guisan/widget.hpp"
 
+#include <memory>
+
 namespace gcn
 {
     class ListBox;
@@ -105,9 +107,21 @@ namespace gcn
          * @param listBox the listBox to use.
          * @see ListModel, ScrollArea, ListBox.
          */
-        DropDown(ListModel *listModel = nullptr,
-                 ScrollArea *scrollArea = nullptr,
-                 ListBox *listBox = nullptr);
+        DropDown(ListModel* listModel,
+                 ScrollArea* scrollArea,
+                 ListBox* listBox = nullptr);
+
+        /**
+         * Constructor.
+         *
+         * @param listModel the ListModel to use.
+         * @param scrollArea the ScrollArea to use.
+         * @param listBox the listBox to use.
+         * @see ListModel, ScrollArea, ListBox.
+         */
+        DropDown(ListModel* listModel = nullptr,
+                 std::shared_ptr<ScrollArea> scrollArea = nullptr,
+                 std::shared_ptr<ListBox> listBox = nullptr);
 
         /**
          * Destructor.
@@ -269,8 +283,8 @@ namespace gcn
         /**
          * The scroll area used.
          */
-        ScrollArea* mScrollArea = nullptr;
-        ListBox* mListBox = nullptr;
+        std::shared_ptr<ScrollArea> mScrollArea;
+        std::shared_ptr<ListBox> mListBox;
 
         /**
          * The internal focus handler used to keep track of focus for the

--- a/include/guisan/widgets/icon.hpp
+++ b/include/guisan/widgets/icon.hpp
@@ -61,6 +61,8 @@
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
 
+#include <memory>
+
 namespace gcn
 {
     /**
@@ -79,27 +81,40 @@ namespace gcn
          *
          * @param filename The filename of the image to display.
          */
-        Icon(const std::string& filename);
+        explicit Icon(const std::string& filename);
 
         /**
          * Constructor.
          *
          * @param image The image to display.
          */
-        Icon(const Image* image);
+        explicit Icon(const Image* image);
+
+        /**
+         * Constructor.
+         *
+         * @param image The image to display.
+         */
+        explicit Icon(std::shared_ptr<const Image> image);
 
         /**
          * Destructor.
          */
-        ~Icon() override;
+        ~Icon() override = default;
 
         /**
-         * Sets the image to display. Existing image is freed automatically
-         * if it was loaded internally.
+         * Sets the image to display.
          *
-         * @param image The image to display. 
+         * @param image The image to display.
          */
         void setImage(const Image* image);
+
+        /**
+         * Sets the image to display.
+         *
+         * @param image The image to display.
+         */
+        void setImage(std::shared_ptr<const Image> image);
 
         /**
          * Gets the current image.
@@ -116,14 +131,7 @@ namespace gcn
         /**
          * The image to display.
          */
-        const Image* mImage = nullptr;
-
-        /**
-         * True if the image has been loaded internally, false otherwise.
-         * An image not loaded internally should not be deleted in the
-         * destructor.
-         */
-        bool mInternalImage = false;
+        std::shared_ptr<const Image> mImage;
     };
 }
 

--- a/include/guisan/widgets/imagebutton.hpp
+++ b/include/guisan/widgets/imagebutton.hpp
@@ -60,6 +60,8 @@
 #include "guisan/platform.hpp"
 #include "guisan/widgets/button.hpp"
 
+#include <memory>
+
 namespace gcn
 {
     class Image;
@@ -80,19 +82,26 @@ namespace gcn
          *
          * @param filename The filename of the image to display.
          */
-        ImageButton(const std::string& filename);
+        explicit ImageButton(const std::string& filename);
 
         /**
          * Constructor.
          *
          * @param image The image to display.
          */
-        ImageButton(const Image* image);
+        explicit ImageButton(const Image* image);
+
+        /**
+         * Constructor.
+         *
+         * @param image The image to display.
+         */
+        explicit ImageButton(std::shared_ptr<const Image> image);
 
         /**
          * Destructor.
          */
-        ~ImageButton() override;
+        ~ImageButton() override = default;
 
         /**
          * Adjusts the size of the image button to fit the image.
@@ -100,12 +109,18 @@ namespace gcn
         void adjustSize();
 
         /**
-         * Sets the image to display. Existing Image is freed automatically, 
-         * if it was loaded internally.
+         * Sets the image to display.
          *
          * @param image The image to display.
          */
         void setImage(const Image* image);
+
+        /**
+         * Sets the image to display.
+         *
+         * @param image The image to display.
+         */
+        void setImage(std::shared_ptr<const Image> image);
 
         /**
          * Gets current image.
@@ -119,14 +134,7 @@ namespace gcn
         void draw(gcn::Graphics* graphics) override;
 
     protected:
-        const Image* mImage = nullptr;
-
-        /**
-         * True if the image has been loaded internally, false otherwise.
-         * An image not loaded internally should not be deleted in the
-         * destructor.
-         */
-        bool mInternalImage = false;
+        std::shared_ptr<const Image> mImage;
     };
 }
 #endif

--- a/include/guisan/widgets/imagetextbutton.hpp
+++ b/include/guisan/widgets/imagetextbutton.hpp
@@ -86,7 +86,15 @@ namespace gcn
          * @param image The image to display.
          * @param caption The text to display.
          */
-        ImageTextButton(Image* image, const std::string& caption);
+        ImageTextButton(const Image* image, const std::string& caption);
+
+        /**
+         * Constructor.
+         *
+         * @param image The image to display.
+         * @param caption The text to display.
+         */
+        ImageTextButton(std::shared_ptr<const Image> image, const std::string& caption);
 
         /**
          * Destructor.

--- a/include/guisan/widgets/tab.hpp
+++ b/include/guisan/widgets/tab.hpp
@@ -57,12 +57,13 @@
 #ifndef GCN_TAB_HPP
 #define GCN_TAB_HPP
 
-#include <map>
-#include <string>
-
 #include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
 
 namespace gcn
 {
@@ -144,7 +145,7 @@ namespace gcn
         /**
          * Holds the label of the tab.
          */
-        Label* mLabel = nullptr;
+        std::unique_ptr<Label> mLabel;
 
         /**
          * Holds the tabbed area the tab is a part of.

--- a/include/guisan/widgets/tabbedarea.hpp
+++ b/include/guisan/widgets/tabbedarea.hpp
@@ -57,15 +57,16 @@
 #ifndef GCN_TABBEDAREA_HPP
 #define GCN_TABBEDAREA_HPP
 
-#include <map>
-#include <string>
-#include <vector>
-
 #include "guisan/actionlistener.hpp"
 #include "guisan/keylistener.hpp"
 #include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace gcn
 {
@@ -272,19 +273,19 @@ namespace gcn
         /**
          * Holds the container for the tabs.
          */
-        Container* mTabContainer = nullptr;
+        std::unique_ptr<Container> mTabContainer;
 
         /**
          * Holds the container for the widgets.
          */
-        Container* mWidgetContainer = nullptr;
+        std::unique_ptr<Container> mWidgetContainer;
 
         /**
          * Holds a vector of tabs to delete in the destructor.
          * A tab that is to be deleted is a tab that has been
          * internally created by the tabbed area.
          */
-        std::vector<Tab*> mTabsToDelete;
+        std::vector<std::unique_ptr<Tab>> mTabsToDelete;
 
         /**
          * A map between a tab and a widget to display when the

--- a/include/guisan/widgets/textbox.hpp
+++ b/include/guisan/widgets/textbox.hpp
@@ -57,14 +57,14 @@
 #ifndef GCN_TEXTBOX_HPP
 #define GCN_TEXTBOX_HPP
 
-#include <ctime>
-#include <string>
-#include <vector>
-
 #include "guisan/keylistener.hpp"
 #include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace gcn
 {
@@ -90,6 +90,11 @@ namespace gcn
          * @param text The default text of the text box.
          */
         TextBox(const std::string& text);
+
+        /**
+         * Destructor.
+         */
+        ~TextBox() override;
 
         /**
          * Sets the text of the text box.
@@ -272,7 +277,7 @@ namespace gcn
         /**
          * Holds the text of the text box.
          */
-        Text* mText = nullptr;
+        std::unique_ptr<Text> mText;
 
         /**
          * True if the text box is editable, false otherwise.

--- a/include/guisan/widgets/textfield.hpp
+++ b/include/guisan/widgets/textfield.hpp
@@ -62,6 +62,7 @@
 #include "guisan/platform.hpp"
 #include "guisan/widget.hpp"
 
+#include <memory>
 #include <string>
 
 namespace gcn
@@ -89,6 +90,11 @@ namespace gcn
          * @param text The default text of the text field.
          */
         TextField(const std::string& text);
+
+        /**
+         * Destructor.
+         */
+        ~TextField() override;
 
         /**
          * Sets the text of the text field.
@@ -190,7 +196,7 @@ namespace gcn
         /**
          * Holds the text of the text field.
          */
-        Text* mText = nullptr;
+        std::unique_ptr<Text> mText;
 
         /**
          * Holds the amount scrolled in x. If a user types more characters than

--- a/src/imagefont.cpp
+++ b/src/imagefont.cpp
@@ -69,89 +69,60 @@
 
 namespace gcn
 {
-    ImageFont::ImageFont(const std::string& filename, const std::string& glyphs)
+
+    namespace
     {
-        mFilename = filename;
-        mImage = Image::load(filename, false);
-
-        Color separator = mImage->getPixel(0, 0);
-
-        int i = 0;
-        for (i = 0;
-             i < mImage->getWidth() && separator == mImage->getPixel(i, 0);
-             ++i)
+        int computeGlyphHeight(Image* imagePtr)
         {
-        }
+            if (imagePtr == nullptr)
+            {
+                throw GCN_EXCEPTION("Font image is nullptr");
+            }
+            Image& image = *imagePtr;
+            const Color separator = image.getPixel(0, 0);
 
-        if (i >= mImage->getWidth())
-        {
+            for (int i = 1; i != image.getWidth(); ++i)
+            {
+                if (separator == image.getPixel(i, 0))
+                {
+                    continue;
+                }
+                for (int j = 1; j != image.getHeight(); ++j)
+                {
+                    if (separator == image.getPixel(i, j))
+                    {
+                        return j;
+                    }
+                }
+                return image.getHeight();
+            }
             throw GCN_EXCEPTION("Corrupt image.");
         }
+    } // namespace
 
-        int j;
-        for (j = 0; j < mImage->getHeight(); ++j)
-        {
-            if (separator == mImage->getPixel(i, j))
-            {
-                break;
-            }
-        }
+    ImageFont::ImageFont(const std::string& filename, const std::string& glyphs) :
+        ImageFont(
+            std::shared_ptr<Image>{Image::load(filename, false), std::default_delete<Image>{}},
+            glyphs)
+    {}
 
-        mHeight = j;
-        int x = 0, y = 0;
-        unsigned char k;
+    ImageFont::ImageFont(Image* image, const std::string& glyphs) :
+        ImageFont(std::shared_ptr<Image>{image, std::default_delete<Image>{}}, glyphs)
+    {}
 
-        for (i = 0; i < (int) glyphs.size(); ++i)
-        {
-            k = glyphs.at(i);
-            mGlyph[k] = scanForGlyph(k, x, y, separator);
-            // Update x och y with new coordinates.
-            x = mGlyph[k].x + mGlyph[k].width;
-            y = mGlyph[k].y;
-        }
-
-        mImage->convertToDisplayFormat();
-    }
-
-    ImageFont::ImageFont(Image* image, const std::string& glyphs)
+    ImageFont::ImageFont(std::shared_ptr<Image> image, const std::string& glyphs) :
+        mImage(std::move(image)),
+        mHeight(computeGlyphHeight(mImage.get()))
     {
-        mFilename = "Image*";
-        if (image == nullptr)
-        {
-            throw GCN_EXCEPTION("Font image is nullptr");
-        }
-        mImage = image;
-
         const Color separator = mImage->getPixel(0, 0);
-
-        int i = 0;
-        for (i = 0; i < mImage->getWidth() && separator == mImage->getPixel(i, 0); ++i)
-        {}
-
-        if (i >= mImage->getWidth())
+        int x = 0;
+        int y = 0;
+        for (unsigned char c : glyphs)
         {
-            throw GCN_EXCEPTION("Corrupt image.");
-        }
-
-        int j = 0;
-        for (j = 0; j < mImage->getHeight(); ++j)
-        {
-            if (separator == mImage->getPixel(i, j))
-            {
-                break;
-            }
-        }
-
-        mHeight = j;
-        int x = 0, y = 0;
-
-        for (i = 0; i < (int) glyphs.size(); ++i)
-        {
-            const unsigned char k = glyphs.at(i);
-            mGlyph[k] = scanForGlyph(k, x, y, separator);
+            mGlyph[c] = scanForGlyph(c, x, y, separator);
             // Update x and y with new coordinates.
-            x = mGlyph[k].x + mGlyph[k].width;
-            y = mGlyph[k].y;
+            x = mGlyph[c].x + mGlyph[c].width;
+            y = mGlyph[c].y;
         }
 
         mImage->convertToDisplayFormat();
@@ -159,53 +130,22 @@ namespace gcn
 
     ImageFont::ImageFont(const std::string& filename,
                          unsigned char glyphsFrom,
-                         unsigned char glyphsTo)
+                         unsigned char glyphsTo) :
+        mImage{Image::load(filename, false), std::default_delete<Image>{}},
+        mHeight(computeGlyphHeight(mImage.get()))
     {
-        mFilename = filename;
-        mImage = Image::load(filename, false);
-
         const Color separator = mImage->getPixel(0, 0);
 
-        int i;
-        for (i=0; separator == mImage->getPixel(i, 0)
-                 && i < mImage->getWidth(); ++i)
-        {
-        }
-
-        if (i >= mImage->getWidth())
-        {
-            throw GCN_EXCEPTION("Corrupt image.");
-        }
-
-        int j;
-        for (j = 0; j < mImage->getHeight(); ++j)
-        {
-            if (separator == mImage->getPixel(i, j))
-            {
-                break;
-            }
-        }
-
-        mHeight = j;
-        int x = 0, y = 0;
-
-        for (i = glyphsFrom; i < glyphsTo + 1; i++)
+        int x = 0;
+        int y = 0;
+        for (int i = glyphsFrom; i < glyphsTo + 1; i++)
         {
             mGlyph[i] = scanForGlyph(i, x, y, separator);
-            // Update x och y with new coordinates.
+            // Update x and y with new coordinates.
             x = mGlyph[i].x + mGlyph[i].width;
             y = mGlyph[i].y;
         }
-
         mImage->convertToDisplayFormat();
-
-        mRowSpacing = 0;
-        mGlyphSpacing = 0;
-    }
-
-    ImageFont::~ImageFont()
-    {
-        delete mImage;
     }
 
     int ImageFont::getWidth(unsigned char glyph) const
@@ -236,7 +176,7 @@ namespace gcn
             return mGlyph[(int)(' ')].width + mGlyphSpacing;
         }
 
-        graphics->drawImage(mImage,
+        graphics->drawImage(mImage.get(),
                             mGlyph[glyph].x,
                             mGlyph[glyph].y,
                             x,
@@ -294,9 +234,7 @@ namespace gcn
                 {
                     std::string str;
                     std::ostringstream os(str);
-                    os << "Image ";
-                    os << mFilename;
-                    os << " with font is corrupt near character '";
+                    os << "Image with font is corrupt near character '";
                     os << glyph;
                     os << "'";
                     throw GCN_EXCEPTION(os.str());
@@ -317,9 +255,7 @@ namespace gcn
             {
                 std::string str;
                 std::ostringstream os(str);
-                os << "Image ";
-                os << mFilename;
-                os << " with font is corrupt near character '";
+                os << "Image with font is corrupt near character '";
                 os << glyph;
                 os << "'";
                 throw GCN_EXCEPTION(os.str());

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -67,10 +67,17 @@
 
 namespace gcn
 {
-    DropDown::DropDown(ListModel *listModel,
-                       ScrollArea *scrollArea, ListBox* listBox) :
-        mScrollArea(scrollArea ? scrollArea : new ScrollArea()),
-        mListBox(listBox ? listBox : new ListBox()),
+    DropDown::DropDown(ListModel* listModel, ScrollArea* scrollArea, ListBox* listBox) :
+        DropDown(listModel,
+                 std::shared_ptr<ScrollArea>(scrollArea, [](ScrollArea*) {}),
+                 std::shared_ptr<ListBox>(listBox, [](ListBox*) {}))
+    {}
+
+    DropDown::DropDown(ListModel* listModel,
+                       std::shared_ptr<ScrollArea> scrollArea,
+                       std::shared_ptr<ListBox> listBox) :
+        mScrollArea(scrollArea ? scrollArea : std::make_shared<ScrollArea>()),
+        mListBox(listBox ? listBox : std::make_shared<ListBox>()),
         mInternalScrollArea(scrollArea == nullptr),
         mInternalListBox(listBox == nullptr)
     {
@@ -79,8 +86,8 @@ namespace gcn
 
         setInternalFocusHandler(&mInternalFocusHandler);
 
-        mScrollArea->setContent(mListBox);
-        add(mScrollArea);
+        mScrollArea->setContent(mListBox.get());
+        add(mScrollArea.get());
 
         mListBox->addActionListener(this);
         mListBox->addSelectionListener(this);
@@ -101,14 +108,8 @@ namespace gcn
 
     DropDown::~DropDown()
     {
-        if (widgetExists(mListBox))
+        if (widgetExists(mListBox.get()))
             mListBox->removeSelectionListener(this);
-
-        if (mInternalScrollArea)
-            delete mScrollArea;
-
-        if (mInternalListBox)
-            delete mListBox;
 
         setInternalFocusHandler(nullptr);
     }
@@ -464,7 +465,7 @@ namespace gcn
 
     void DropDown::death(const Event& event)
     {
-        if (event.getSource() == mScrollArea)
+        if (event.getSource() == mScrollArea.get())
         {
             mScrollArea = nullptr;
         }
@@ -491,6 +492,7 @@ namespace gcn
 
     void DropDown::setBaseColor(const Color& color)
     {
+
         if (mInternalScrollArea)
         {
             mScrollArea->setBaseColor(color);

--- a/src/widgets/icon.cpp
+++ b/src/widgets/icon.cpp
@@ -71,39 +71,46 @@ namespace gcn
         setSize(0, 0);
     }
 
-    Icon::Icon(const std::string& filename) : mImage(Image::load(filename)), mInternalImage(true)
-    {
-        setSize(mImage->getWidth(), mImage->getHeight());
-    }
+    Icon::Icon(const std::string& filename) :
+        Icon({Image::load(filename), std::default_delete<const Image>{}})
+    {}
 
-    Icon::Icon(const Image* image) : mImage(image)
-    {
-        setSize(mImage->getWidth(), mImage->getHeight());
-    }
+    Icon::Icon(const Image* image) : Icon({image, [](const Image*) {}})
+    {}
 
-    Icon::~Icon()
+    Icon::Icon(std::shared_ptr<const Image> image) : mImage(std::move(image))
     {
-        if (mInternalImage)
+        if (mImage)
         {
-            delete mImage;
+            setSize(mImage->getWidth(), mImage->getHeight());
+        }
+        else
+        {
+            setSize(0, 0);
         }
     }
 
     void Icon::setImage(const Image* image)
     {
-        if (mInternalImage)
-        {
-            delete mImage;
-        }
+        setImage({image, [](const Image*) {}});
+    }
 
-        mImage = image;
-        mInternalImage = false;
-        setSize(mImage->getWidth(), mImage->getHeight());
+    void Icon::setImage(std::shared_ptr<const Image> image)
+    {
+        mImage = std::move(image);
+        if (mImage)
+        {
+            setSize(mImage->getWidth(), mImage->getHeight());
+        }
+        else
+        {
+            setSize(0, 0);
+        }
     }
 
     const Image* Icon::getImage() const
     {
-        return mImage;
+        return mImage.get();
     }
 
     void Icon::draw(Graphics* graphics)
@@ -112,8 +119,8 @@ namespace gcn
         {
             const int x = (getWidth() - mImage->getWidth()) / 2;
             const int y = (getHeight() - mImage->getHeight()) / 2;
-            graphics->drawImage(mImage, x, y);
+            graphics->drawImage(mImage.get(), x, y);
         }
     }
 
-}
+} // namespace gcn

--- a/src/widgets/imagetextbutton.cpp
+++ b/src/widgets/imagetextbutton.cpp
@@ -67,14 +67,21 @@
 
 namespace gcn
 {
-    ImageTextButton::ImageTextButton(const std::string& filename, const std::string& caption) : ImageButton(filename)
+    ImageTextButton::ImageTextButton(const std::string& filename, const std::string& caption) :
+        ImageButton(filename)
     {
         setCaption(caption);
         setWidth(mImage->getWidth() + mImage->getWidth() / 2);
         setHeight(mImage->getHeight() + mImage->getHeight() / 2);
     }
 
-    ImageTextButton::ImageTextButton(Image* image, const std::string& caption) : ImageButton(image)
+    ImageTextButton::ImageTextButton(const Image* image, const std::string& caption) :
+        ImageTextButton({image, [](const auto*) {}}, caption)
+    {}
+
+    ImageTextButton::ImageTextButton(std::shared_ptr<const Image> image,
+                                     const std::string& caption) :
+        ImageButton(std::move(image))
     {
         setCaption(caption);
         setWidth(mImage->getWidth() + mImage->getWidth() / 2);
@@ -181,12 +188,12 @@ namespace gcn
 
         if (isPressed())
         {
-            graphics->drawImage(mImage, imageX + 1, imageY + 1);
+            graphics->drawImage(mImage.get(), imageX + 1, imageY + 1);
             graphics->drawText(mCaption, textX + 1, textY + 1, Graphics::Left, isEnabled());
         }
         else
         {
-            graphics->drawImage(mImage, imageX, imageY);
+            graphics->drawImage(mImage.get(), imageX, imageY);
             graphics->drawText(mCaption, textX, textY, Graphics::Left, isEnabled());
            
             if (isFocused())

--- a/src/widgets/tab.cpp
+++ b/src/widgets/tab.cpp
@@ -68,19 +68,16 @@
 
 namespace gcn
 {
-    Tab::Tab() : mLabel(new Label())
+    Tab::Tab() : mLabel(std::make_unique<Label>())
     {
         mLabel->setPosition(6, 6);
-        add(mLabel);
+        add(mLabel.get());
         setFrameSize(1);
 
         addMouseListener(this);
     }
 
-    Tab::~Tab()
-    {
-        delete mLabel;
-    }
+    Tab::~Tab() = default;
 
     void Tab::adjustSize()
     {

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -71,7 +71,7 @@ namespace gcn
     TextBox::TextBox() : TextBox("")
     {}
 
-    TextBox::TextBox(const std::string& text) : mText(new Text(text))
+    TextBox::TextBox(const std::string& text) : mText(std::make_unique<Text>(text))
     {
         setFocusable(true);
 
@@ -80,6 +80,8 @@ namespace gcn
         adjustSize();
         setFrameSize(1);
     }
+
+    TextBox::~TextBox() = default;
 
     void TextBox::setText(const std::string& text)
     {

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -68,7 +68,7 @@
 
 namespace gcn
 {
-    TextField::TextField() : mText(new Text())
+    TextField::TextField() : mText(std::make_unique<Text>())
     {
         setFocusable(true);
 
@@ -78,7 +78,7 @@ namespace gcn
         adjustHeight();
     }
 
-    TextField::TextField(const std::string& text) : mText(new Text(text))
+    TextField::TextField(const std::string& text) : mText(std::make_unique<Text>(text))
     {
         setFocusable(true);
 
@@ -87,6 +87,8 @@ namespace gcn
 
         adjustSize();
     }
+
+    TextField::~TextField() = default;
 
     void TextField::setText(const std::string& text)
     {


### PR DESCRIPTION
I still keep old interface, and mark as `[[deprecated]]` the overload taking an owning pointer.
I didn't change `Image::load` neither, as I cannot overload on return type, to keep current API.