### PR TITLE
Add PasswordField widget

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -112,6 +112,7 @@ widget_headers = [
     'include/guisan/widgets/label.hpp',
     'include/guisan/widgets/listbox.hpp',
     'include/guisan/widgets/messagebox.hpp',
+    'include/guisan/widgets/passwordfield.hpp',
     'include/guisan/widgets/progressbar.hpp',
     'include/guisan/widgets/radiobutton.hpp',
     'include/guisan/widgets/scrollarea.hpp',

--- a/examples/widgets_example.hpp
+++ b/examples/widgets_example.hpp
@@ -79,6 +79,8 @@ namespace WidgetsExample
 
             textField = std::make_unique<gcn::TextField>("Text field");
 
+            passwordField = std::make_unique<gcn::PasswordField>("password");
+
             textBox = std::make_unique<gcn::TextBox>("Lorem ipsum dolor sit amet consectetur\n"
                                                      "adipiscing elit Integer vitae ultrices\n"
                                                      "eros Curabitur malesuada dolor imperdieat\n"
@@ -150,6 +152,7 @@ namespace WidgetsExample
             top->add(imageButton.get(), 10, 290);
             top->add(imageTextButton.get(), 10, 380);
             top->add(textField.get(), 375, 10);
+            top->add(passwordField.get(), 425, 10);
             top->add(textBoxScrollArea.get(), 290, 50);
             top->add(inputBox.get(), 270, 180);
             top->add(listBox.get(), 290, 200);
@@ -228,6 +231,7 @@ namespace WidgetsExample
         std::unique_ptr<gcn::ImageTextButton> imageTextButton; // An image text button
         std::unique_ptr<gcn::InputBox> inputBox; // An input box
         std::unique_ptr<gcn::TextField> textField; // One-line text field
+        std::unique_ptr<gcn::PasswordField> passwordField; // One-line password field
         std::unique_ptr<gcn::TextBox> textBox; // Multi-line text box
         std::unique_ptr<gcn::ScrollArea> textBoxScrollArea; // Scroll area for the text box
         std::unique_ptr<gcn::ListBox> listBox; // A list box

--- a/include/guisan/widgets/passwordfield.hpp
+++ b/include/guisan/widgets/passwordfield.hpp
@@ -65,8 +65,8 @@ namespace gcn
 {
     /**
      * A text field in which you can write or display a line of text. 
-	 * Unlike a TextField the text will appear as '*' instead of the real content. 
-	 * If for some reason the Font you are using does not contain this character, the 
+	 * Unlike a TextField the text will appear as masked, instead of the real content. 
+	 * If for some reason the Font you are using does not contain the character, the 
 	 * PasswordField will be filled by spaces. 
      */
     class GCN_CORE_DECLSPEC PasswordField:
@@ -88,7 +88,16 @@ namespace gcn
         // Inherited from Widget
 
         void draw(Graphics* graphics) override;
-
+        
+        /**
+         * Set the masking character to hide the password
+         *
+         * @param mask the masking character
+         */
+        void setMaskingChar(const char mask);
+        
+    private:
+        char masking('*');
     };
 }
 

--- a/include/guisan/widgets/passwordfield.hpp
+++ b/include/guisan/widgets/passwordfield.hpp
@@ -97,7 +97,7 @@ namespace gcn
         void setMaskingChar(const char mask);
         
     private:
-        char masking('*');
+        char masking = '*';
     };
 }
 

--- a/include/guisan/widgets/passwordfield.hpp
+++ b/include/guisan/widgets/passwordfield.hpp
@@ -6,11 +6,11 @@
  * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
  * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
  *
- * Copyright (c) 2004, 2005, 2006, 2007 Olof NaessÃ©n and Per Larsson
+ * Copyright (c) 2004, 2005, 2006, 2007 Olof Naessén and Per Larsson
  *
  *                                                         Js_./
  * Per Larsson a.k.a finalman                          _RqZ{a<^_aa
- * Olof NaessÃ©n a.k.a jansem/yakslem                _asww7!uY`>  )\a//
+ * Olof Naessén a.k.a jansem/yakslem                _asww7!uY`>  )\a//
  *                                                 _Qhm`] _f "'c  1!5m
  * Visit: http://guichan.darkbits.org             )Qk<P ` _: :+' .'  "{[
  *                                               .)j(] .d_/ '-(  P .   S
@@ -54,77 +54,46 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GCN_GUISAN_HPP
-#define GCN_GUISAN_HPP
+#ifndef GCN_PASSWORDFIELD_HPP
+#define GCN_PASSWORDFIELD_HPP
 
-#include <guisan/actionevent.hpp>
-#include <guisan/actionlistener.hpp>
-#include <guisan/cliprectangle.hpp>
-#include <guisan/color.hpp>
-#include <guisan/containerevent.hpp>
-#include <guisan/containerlistener.hpp>
-#include <guisan/deathlistener.hpp>
-#include <guisan/event.hpp>
-#include <guisan/exception.hpp>
-#include <guisan/focushandler.hpp>
-#include <guisan/focuslistener.hpp>
-#include <guisan/font.hpp>
-#include <guisan/genericinput.hpp>
-#include <guisan/graphics.hpp>
-#include <guisan/gui.hpp>
-#include <guisan/image.hpp>
-#include <guisan/imagefont.hpp>
-#include <guisan/imageloader.hpp>
-#include <guisan/input.hpp>
-#include <guisan/inputevent.hpp>
-#include <guisan/key.hpp>
-#include <guisan/keyevent.hpp>
-#include <guisan/keyinput.hpp>
-#include <guisan/keylistener.hpp>
-#include <guisan/listmodel.hpp>
-#include <guisan/mouseevent.hpp>
-#include <guisan/mouseinput.hpp>
-#include <guisan/mouselistener.hpp>
-#include <guisan/rectangle.hpp>
-#include <guisan/selectionevent.hpp>
-#include <guisan/selectionlistener.hpp>
-#include <guisan/widget.hpp>
-#include <guisan/widgetlistener.hpp>
-
-#include <guisan/widgets/button.hpp>
-#include <guisan/widgets/checkbox.hpp>
-#include <guisan/widgets/container.hpp>
-#include <guisan/widgets/dropdown.hpp>
-#include <guisan/widgets/icon.hpp>
-#include <guisan/widgets/imagebutton.hpp>
-#include <guisan/widgets/imagetextbutton.hpp>
-#include <guisan/widgets/inputbox.hpp>
-#include <guisan/widgets/label.hpp>
-#include <guisan/widgets/listbox.hpp>
-#include <guisan/widgets/messagebox.hpp>
-#include <guisan/widgets/passwordfield.hpp>
-#include <guisan/widgets/progressbar.hpp>
-#include <guisan/widgets/scrollarea.hpp>
-#include <guisan/widgets/slider.hpp>
-#include <guisan/widgets/radiobutton.hpp>
-#include <guisan/widgets/tab.hpp>
-#include <guisan/widgets/tabbedarea.hpp>
-#include <guisan/widgets/textbox.hpp>
-#include <guisan/widgets/textfield.hpp>
-#include <guisan/widgets/togglebutton.hpp>
-#include <guisan/widgets/window.hpp>
-
+#include "guisan/keylistener.hpp"
+#include "guisan/mouselistener.hpp"
 #include "guisan/platform.hpp"
+#include "guisan/widget.hpp"
+#include "guisan/widgets/textfield.hpp"
 
-extern "C"
+#include <string>
+
+namespace gcn
 {
     /**
-     * Gets the the version of Guisan. As it is a C function
-     * it can be used to check for Guisan with autotools.
-     *
-     * @return the version of Guisan.
+     * A text field in which you can write or display a line of text. 
+	 * Unlike a TextField the text will appear as '*' instead of the real content. 
+	 * If for some reason the Font you are using does not contain this character, the 
+	 * PasswordField will be filled by spaces. 
      */
-    GCN_CORE_DECLSPEC extern const char* gcnGuisanVersion();
+    class GCN_CORE_DECLSPEC PasswordField:
+        public TextField
+    {
+    public:
+        /**
+         * Default constructor.
+         */
+        PasswordField();
+
+        /**
+         * Constructor. Initializes the passwordfield with a given string.
+         *
+         * @param text the initial text.
+         */
+        PasswordField(const std::string& text);
+
+        // Inherited from Widget
+
+        void draw(Graphics* graphics) override;
+
+    };
 }
 
-#endif // end GCN_GUISAN_HPP
+#endif // end GCN_PASSWORDFIELD_HPP

--- a/include/guisan/widgets/passwordfield.hpp
+++ b/include/guisan/widgets/passwordfield.hpp
@@ -96,6 +96,13 @@ namespace gcn
          */
         void setMaskingChar(const char mask);
         
+        /**
+         * Get the masking character
+         * 
+         * @return the masking character
+         */
+        const char getMaskingChar() const;
+        
     private:
         char masking = '*';
     };

--- a/include/guisan/widgets/passwordfield.hpp
+++ b/include/guisan/widgets/passwordfield.hpp
@@ -6,11 +6,11 @@
  * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
  * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
  *
- * Copyright (c) 2004, 2005, 2006, 2007 Olof Naessén and Per Larsson
+ * Copyright (c) 2004, 2005, 2006, 2007 Olof NaessÃ©n and Per Larsson
  *
  *                                                         Js_./
  * Per Larsson a.k.a finalman                          _RqZ{a<^_aa
- * Olof Naessén a.k.a jansem/yakslem                _asww7!uY`>  )\a//
+ * Olof NaessÃ©n a.k.a jansem/yakslem                _asww7!uY`>  )\a//
  *                                                 _Qhm`] _f "'c  1!5m
  * Visit: http://guichan.darkbits.org             )Qk<P ` _: :+' .'  "{[
  *                                               .)j(] .d_/ '-(  P .   S
@@ -57,10 +57,6 @@
 #ifndef GCN_PASSWORDFIELD_HPP
 #define GCN_PASSWORDFIELD_HPP
 
-#include "guisan/keylistener.hpp"
-#include "guisan/mouselistener.hpp"
-#include "guisan/platform.hpp"
-#include "guisan/widget.hpp"
 #include "guisan/widgets/textfield.hpp"
 
 #include <string>
@@ -87,7 +83,7 @@ namespace gcn
          *
          * @param text the initial text.
          */
-        PasswordField(const std::string& text);
+        explicit PasswordField(const std::string& text);
 
         // Inherited from Widget
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -44,6 +44,7 @@ widget_sources = [
 	'widgets/label.cpp',
 	'widgets/listbox.cpp',
 	'widgets/messagebox.cpp',
+	'widgets/passwordfield.cpp',
 	'widgets/progressbar.cpp',
 	'widgets/radiobutton.cpp',
 	'widgets/scrollarea.cpp',

--- a/src/widgets/passwordfield.cpp
+++ b/src/widgets/passwordfield.cpp
@@ -6,11 +6,11 @@
  * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
  * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
  *
- * Copyright (c) 2004, 2005, 2006, 2007 Olof Naessén and Per Larsson
+ * Copyright (c) 2004, 2005, 2006, 2007 Olof NaessÃ©n and Per Larsson
  *
  *                                                         Js_./
  * Per Larsson a.k.a finalman                          _RqZ{a<^_aa
- * Olof Naessén a.k.a jansem/yakslem                _asww7!uY`>  )\a//
+ * Olof NaessÃ©n a.k.a jansem/yakslem                _asww7!uY`>  )\a//
  *                                                 _Qhm`] _f "'c  1!5m
  * Visit: http://guichan.darkbits.org             )Qk<P ` _: :+' .'  "{[
  *                                               .)j(] .d_/ '-(  P .   S
@@ -60,10 +60,6 @@
 
 #include "guisan/widgets/passwordfield.hpp"
 
-#include "guisan/font.hpp"
-#include "guisan/graphics.hpp"
-#include "guisan/key.hpp"
-#include "guisan/mouseinput.hpp"
 #include "guisan/text.hpp"
 
 namespace gcn
@@ -81,8 +77,8 @@ namespace gcn
 
     void PasswordField::draw(Graphics* graphics)
     {
-        std::string encodedText(mText->getRow(0).size(), '*');
-        std::string realText(mText->getRow(0));
+        const std::string realText(mText->getRow(0));
+        const std::string encodedText(realText.size(), '*');
         
         // Switch replacement text before drawing it to hide it
         mText->setRow(0, encodedText);

--- a/src/widgets/passwordfield.cpp
+++ b/src/widgets/passwordfield.cpp
@@ -6,11 +6,11 @@
  * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
  * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
  *
- * Copyright (c) 2004, 2005, 2006, 2007 Olof NaessÃ©n and Per Larsson
+ * Copyright (c) 2004, 2005, 2006, 2007 Olof Naessén and Per Larsson
  *
  *                                                         Js_./
  * Per Larsson a.k.a finalman                          _RqZ{a<^_aa
- * Olof NaessÃ©n a.k.a jansem/yakslem                _asww7!uY`>  )\a//
+ * Olof Naessén a.k.a jansem/yakslem                _asww7!uY`>  )\a//
  *                                                 _Qhm`] _f "'c  1!5m
  * Visit: http://guichan.darkbits.org             )Qk<P ` _: :+' .'  "{[
  *                                               .)j(] .d_/ '-(  P .   S
@@ -54,77 +54,40 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GCN_GUISAN_HPP
-#define GCN_GUISAN_HPP
+/*
+ * For comments regarding functions please see the header file.
+ */
 
-#include <guisan/actionevent.hpp>
-#include <guisan/actionlistener.hpp>
-#include <guisan/cliprectangle.hpp>
-#include <guisan/color.hpp>
-#include <guisan/containerevent.hpp>
-#include <guisan/containerlistener.hpp>
-#include <guisan/deathlistener.hpp>
-#include <guisan/event.hpp>
-#include <guisan/exception.hpp>
-#include <guisan/focushandler.hpp>
-#include <guisan/focuslistener.hpp>
-#include <guisan/font.hpp>
-#include <guisan/genericinput.hpp>
-#include <guisan/graphics.hpp>
-#include <guisan/gui.hpp>
-#include <guisan/image.hpp>
-#include <guisan/imagefont.hpp>
-#include <guisan/imageloader.hpp>
-#include <guisan/input.hpp>
-#include <guisan/inputevent.hpp>
-#include <guisan/key.hpp>
-#include <guisan/keyevent.hpp>
-#include <guisan/keyinput.hpp>
-#include <guisan/keylistener.hpp>
-#include <guisan/listmodel.hpp>
-#include <guisan/mouseevent.hpp>
-#include <guisan/mouseinput.hpp>
-#include <guisan/mouselistener.hpp>
-#include <guisan/rectangle.hpp>
-#include <guisan/selectionevent.hpp>
-#include <guisan/selectionlistener.hpp>
-#include <guisan/widget.hpp>
-#include <guisan/widgetlistener.hpp>
+#include "guisan/widgets/passwordfield.hpp"
 
-#include <guisan/widgets/button.hpp>
-#include <guisan/widgets/checkbox.hpp>
-#include <guisan/widgets/container.hpp>
-#include <guisan/widgets/dropdown.hpp>
-#include <guisan/widgets/icon.hpp>
-#include <guisan/widgets/imagebutton.hpp>
-#include <guisan/widgets/imagetextbutton.hpp>
-#include <guisan/widgets/inputbox.hpp>
-#include <guisan/widgets/label.hpp>
-#include <guisan/widgets/listbox.hpp>
-#include <guisan/widgets/messagebox.hpp>
-#include <guisan/widgets/passwordfield.hpp>
-#include <guisan/widgets/progressbar.hpp>
-#include <guisan/widgets/scrollarea.hpp>
-#include <guisan/widgets/slider.hpp>
-#include <guisan/widgets/radiobutton.hpp>
-#include <guisan/widgets/tab.hpp>
-#include <guisan/widgets/tabbedarea.hpp>
-#include <guisan/widgets/textbox.hpp>
-#include <guisan/widgets/textfield.hpp>
-#include <guisan/widgets/togglebutton.hpp>
-#include <guisan/widgets/window.hpp>
+#include "guisan/font.hpp"
+#include "guisan/graphics.hpp"
+#include "guisan/key.hpp"
+#include "guisan/mouseinput.hpp"
+#include "guisan/text.hpp"
 
-#include "guisan/platform.hpp"
-
-extern "C"
+namespace gcn
 {
-    /**
-     * Gets the the version of Guisan. As it is a C function
-     * it can be used to check for Guisan with autotools.
-     *
-     * @return the version of Guisan.
-     */
-    GCN_CORE_DECLSPEC extern const char* gcnGuisanVersion();
-}
+    PasswordField::PasswordField() : TextField()
+    {
 
-#endif // end GCN_GUISAN_HPP
+    }
+
+    PasswordField::PasswordField(const std::string& text) : TextField(text)
+    {
+
+    }
+
+
+    void PasswordField::draw(Graphics* graphics)
+    {
+        std::string encodedText(mText->getRow(0).size(), '*');
+        std::string realText(mText->getRow(0));
+        
+        // Switch replacement text before drawing it to hide it
+        mText->setRow(0, encodedText);
+        TextField::draw(graphics);
+        mText->setRow(0, realText);
+    }
+
+}

--- a/src/widgets/passwordfield.cpp
+++ b/src/widgets/passwordfield.cpp
@@ -78,12 +78,17 @@ namespace gcn
     void PasswordField::draw(Graphics* graphics)
     {
         const std::string realText(mText->getRow(0));
-        const std::string encodedText(realText.size(), '*');
+        const std::string encodedText(realText.size(), masking);
         
         // Switch replacement text before drawing it to hide it
         mText->setRow(0, encodedText);
         TextField::draw(graphics);
         mText->setRow(0, realText);
+    }
+    
+    void PasswordField::setMaskingChar(const char mask)
+    {
+        masking = mask;
     }
 
 }

--- a/src/widgets/passwordfield.cpp
+++ b/src/widgets/passwordfield.cpp
@@ -90,5 +90,10 @@ namespace gcn
     {
         masking = mask;
     }
+    
+    const char PasswordField::getMaskingChar() const
+    {
+        return masking;
+    }
 
 }


### PR DESCRIPTION
So, this is an old (8 years old) addition I made to my fork of guisan and for some reason, never contributed back to the main repo. Basically, it is just a text field but with hidden text, which is suitable for - you guessed it - passwords. 

I quickly updated it a few days ago to adjust to the upstream changes, but it may need some more improvements before merging. In particular, it may be good to make the masking character configurable through a setter. 